### PR TITLE
chore(git): SCRUM-42 Add Git Commit Message Template

### DIFF
--- a/.github/.gitmessage
+++ b/.github/.gitmessage
@@ -1,0 +1,21 @@
+# Conventional subject
+
+# Body: Explain *what* and *why* (not *how*).
+
+# At the end: Include Co-authored-by for all contributors.
+# Include at least one empty line before it. Format:
+# Co-authored-by: name <ID+USERNAME@users.noreply.github.com>
+#
+# How to Write a Git Commit Message:
+# https://chris.beams.io/posts/git-commit
+#
+# Follow the Conventional Commits format:
+# https://www.conventionalcommits.org/en/v1.0.0
+#
+# 1. Capitalize the subject line
+# 2. Try to put it in 50 chars or less
+# 3. Do not end the subject line with a period
+# 4. Separate subject from body with a blank line
+# 5. Use the imperative mood in the subject line
+# 6. Use the body to explain what and why vs how
+# 7. Wrap the body at 72 characters

--- a/.github/.gitmessage
+++ b/.github/.gitmessage
@@ -1,11 +1,7 @@
-# Conventional subject
+# Subject in Conventional Commits format
 
-# Body: Explain *what* and *why* (not *how*).
+# Body: Provide a detailed explanation why changes were made
 
-# At the end: Include Co-authored-by for all contributors.
-# Include at least one empty line before it. Format:
-# Co-authored-by: name <ID+USERNAME@users.noreply.github.com>
-#
 # How to Write a Git Commit Message:
 # https://chris.beams.io/posts/git-commit
 #

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -3,8 +3,7 @@
 # Git Workflow
 
 This project follows a simplified **Git Flow** model.
-
-Full original Git Flow explanation: https://nvie.com/posts/a-successful-git-branching-model
+See the full [original Git Flow explanation](https://nvie.com/posts/a-successful-git-branching-model).
 
 ## Branches
 
@@ -23,16 +22,23 @@ Full original Git Flow explanation: https://nvie.com/posts/a-successful-git-bran
 
 ## Commit messages
 
-We use **Conventional Commits** → https://www.conventionalcommits.org
-
-Jira ticket key should be included.
+Follow the [Conventional Commits](https://www.conventionalcommits.org)
+format with a Jira ticket key included, for example:
 
 ```text
-feat: TK-18 add user registration en dpoint
-fix: TK-19 prevent SQL injection in search
-refactor: TK-23 extract authentication service
-docs: TK-28 update API documentation
-test: TK-20 add tests for password reset
+feat(auth): TK-18 Add user registration endpoint
+fix(search: TK-19 Prevent SQL injection in search
+refactor(auth): TK-23 Extract authentication service
+docs(api): TK-28 Update API documentation
+test(auth): TK-20 Add tests for password reset
+```
+
+### Commit message template
+
+To use the [message template](../.github/.gitmessage), change Git config local settings:
+
+```shell
+git config --local commit.template .github/.gitmessage
 ```
 
 ## Prohibited


### PR DESCRIPTION
**Jira**: [SCRUM-42](https://epam-team-php.atlassian.net/browse/SCRUM-42)

Closes: 

## Description

Improve consistency in commit messages by providing a standardized template.

## Test coverage

Follow the [documentation guidelines](https://github.com/CPAprince/Twitter/blob/feature/SCRUM-42-add-git-commit-message/docs/git-workflow.md#commit-message-template) on how to use the template. After that, stage some changes and run:

```shell
git commit
```

## Screenshots

<img width="814" height="590" alt="Screenshot from 2025-12-07 10-00-37" src="https://github.com/user-attachments/assets/f6ee3359-325c-454b-ad6a-8c51d524d732" />