### PR TITLE
feat(profile): SCRUM-52 Create User Profile on Registration

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -17,6 +17,11 @@ doctrine:
                 dir: '%kernel.project_dir%/src/IAM/Infrastructure/Persistence/Doctrine/Mapping'
                 prefix: Twitter\IAM\Domain
                 is_bundle: false
+            Profile:
+                type: xml
+                dir: '%kernel.project_dir%/src/Profile/Infrastructure/Persistence/Doctrine/Mapping'
+                prefix: Twitter\Profile\Domain
+                is_bundle: false
 when@test:
     doctrine:
         dbal:

--- a/config/packages/doctrine_migrations.yaml
+++ b/config/packages/doctrine_migrations.yaml
@@ -1,4 +1,5 @@
 doctrine_migrations:
     migrations_paths:
         'Twitter\IAM\Infrastructure\Persistence\MySQL\Migration': '%kernel.project_dir%/src/IAM/Infrastructure/Persistence/MySQL/Migration'
+        'Twitter\Profile\Infrastructure\Persistence\MySQL\Migration': '%kernel.project_dir%/src/Profile/Infrastructure/Persistence/MySQL/Migration'
     enable_profiler: false

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -7,3 +7,7 @@ health_check_module:
 api_create_user:
     resource: ../src/IAM/UI/REST/Controller/CreateUserController.php
     type: attribute
+    
+api_create_profile:
+    resource: ../src/Profile/UI/REST/Controller/CreateProfile/CreateProfileController.php
+    type: attribute

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -20,3 +20,14 @@ services:
     
     Twitter\IAM\Domain\User\Model\UserRepository:
         class: Twitter\IAM\Infrastructure\Persistence\MySQL\Repository\MySQLUserRepository
+
+    Twitter\Profile\UI\REST\Controller\:
+        resource: '../src/Profile/UI/REST/Controller/*/*Controller.php'
+        tags: [ 'controller.service_arguments' ]
+        
+    Twitter\Profile\Application\UseCase\CreateProfile\CreateProfileCommandHandler:
+        arguments:
+            $profileRepository: '@Twitter\Profile\Domain\Profile\Model\ProfileRepository'
+
+    Twitter\Profile\Domain\Profile\Model\ProfileRepository:
+        class: Twitter\Profile\Infrastructure\Persistence\MySQL\Repository\MySQLProfileRepository

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -5,14 +5,14 @@ services:
         autowire: true
         autoconfigure: true
     
-    Twitter\IAM\UI\REST\Controller\:
-        resource: '../src/IAM/UI/REST/Controller/*Controller.php'
-        tags: [ 'controller.service_arguments' ]
-    
     Twitter\Shared\Infrastructure\EventSubscriber\ExceptionSubscriber:
         tags: [ 'kernel.event_subscriber' ]
         arguments:
             $environment: '%kernel.environment%'
+    
+    Twitter\IAM\UI\REST\Controller\:
+        resource: '../src/IAM/UI/REST/Controller/*Controller.php'
+        tags: [ 'controller.service_arguments' ]
     
     Twitter\IAM\Application\CreateUser\CreateUserCommandHandler:
         arguments:

--- a/src/Profile/Application/UseCase/CreateProfile/CreateProfileCommand.php
+++ b/src/Profile/Application/UseCase/CreateProfile/CreateProfileCommand.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Profile\Application\UseCase\CreateProfile;
+
+final readonly class CreateProfileCommand
+{
+    public function __construct(
+        public string $userId,
+        public string $name,
+        public ?string $bio = null,
+    ) {}
+}

--- a/src/Profile/Application/UseCase/CreateProfile/CreateProfileCommandHandler.php
+++ b/src/Profile/Application/UseCase/CreateProfile/CreateProfileCommandHandler.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Profile\Application\UseCase\CreateProfile;
+
+use Twitter\Profile\Domain\Profile\Model\Profile;
+use Twitter\Profile\Domain\Profile\Model\ProfileRepository;
+
+final readonly class CreateProfileCommandHandler
+{
+    public function __construct(private ProfileRepository $profileRepository) {}
+
+    public function handle(CreateProfileCommand $command): void
+    {
+        $profile = Profile::create($command->userId, $command->name, $command->bio);
+        $this->profileRepository->add($profile);
+    }
+}

--- a/src/Profile/Domain/Profile/Exception/ProfileAlreadyExistsException.php
+++ b/src/Profile/Domain/Profile/Exception/ProfileAlreadyExistsException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Profile\Domain\Profile\Exception;
+
+use Exception;
+
+final class ProfileAlreadyExistsException extends Exception
+{
+    public function __construct(string $userId)
+    {
+        parent::__construct('Profile already exists for user with id "'.$userId.'"');
+    }
+}

--- a/src/Profile/Domain/Profile/Exception/UserNotFoundException.php
+++ b/src/Profile/Domain/Profile/Exception/UserNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Profile\Domain\Profile\Exception;
+
+use Exception;
+
+final class UserNotFoundException extends Exception
+{
+    public function __construct(string $userId)
+    {
+        parent::__construct('User with id "'.$userId.'" not found');
+    }
+}

--- a/src/Profile/Domain/Profile/Model/Profile.php
+++ b/src/Profile/Domain/Profile/Model/Profile.php
@@ -27,10 +27,10 @@ final class Profile
             ->that($name, 'name')
             ->notBlank()
             ->minLength(3)
-            ->maxLength(60)
+            ->maxLength(50)
             ->that($bio, 'bio')
             ->nullOr()
-            ->maxLength(160)
+            ->maxLength(300)
             ->verifyNow();
 
         return new self(

--- a/src/Profile/Domain/Profile/Model/Profile.php
+++ b/src/Profile/Domain/Profile/Model/Profile.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Profile\Domain\Profile\Model;
+
+use Assert\Assert;
+use DateTimeImmutable;
+
+final class Profile
+{
+    private function __construct(
+        private readonly string $userId,
+        private string $name,
+        private string $bio,
+        private readonly DateTimeImmutable $createdAt,
+        private DateTimeImmutable $updatedAt,
+    ) {}
+
+    public static function create(string $userId, string $name, ?string $bio = null): self
+    {
+        Assert::lazy()
+            ->tryAll()
+            ->that($userId, 'userId')
+            ->notBlank()
+            ->uuid()
+            ->that($name, 'name')
+            ->notBlank()
+            ->minLength(3)
+            ->maxLength(60)
+            ->that($bio, 'bio')
+            ->nullOr()
+            ->maxLength(160)
+            ->verifyNow();
+
+        return new self(
+            $userId,
+            $name,
+            $bio ?? '',
+            new DateTimeImmutable(),
+            new DateTimeImmutable(),
+        );
+    }
+
+    public function userId(): string
+    {
+        return $this->userId;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function bio(): string
+    {
+        return $this->bio;
+    }
+
+    public function createdAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function updatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+}

--- a/src/Profile/Domain/Profile/Model/Profile.php
+++ b/src/Profile/Domain/Profile/Model/Profile.php
@@ -19,18 +19,10 @@ final class Profile
 
     public static function create(string $userId, string $name, ?string $bio = null): self
     {
-        Assert::lazy()
-            ->tryAll()
-            ->that($userId, 'userId')
-            ->notBlank()
-            ->uuid()
-            ->that($name, 'name')
-            ->notBlank()
-            ->minLength(3)
-            ->maxLength(50)
-            ->that($bio, 'bio')
-            ->nullOr()
-            ->maxLength(300)
+        Assert::lazy()->tryAll()
+            ->that($userId, 'userId')->notBlank()->uuid()
+            ->that($name, 'name')->notBlank()->minLength(3)->maxLength(50)
+            ->that($bio, 'bio')->nullOr()->maxLength(300)
             ->verifyNow();
 
         return new self(

--- a/src/Profile/Domain/Profile/Model/ProfileRepository.php
+++ b/src/Profile/Domain/Profile/Model/ProfileRepository.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Profile\Domain\Profile\Model;
+
+interface ProfileRepository
+{
+    public function add(Profile $profile);
+}

--- a/src/Profile/Infrastructure/Persistence/Doctrine/Mapping/Profile.Model.Profile.orm.xml
+++ b/src/Profile/Infrastructure/Persistence/Doctrine/Mapping/Profile.Model.Profile.orm.xml
@@ -12,8 +12,8 @@
             <generator strategy="NONE"/>
         </id>
 
-        <field name="name" column="name" length="60"/>
-        <field name="bio" column="bio" length="160" nullable="true"/>
+        <field name="name" column="name" length="50"/>
+        <field name="bio" column="bio" length="300" nullable="true"/>
         <field name="createdAt" column="created_at" type="datetime_immutable" updatable="false"/>
         <field name="updatedAt" column="updated_at" type="datetime_immutable"/>
 

--- a/src/Profile/Infrastructure/Persistence/Doctrine/Mapping/Profile.Model.Profile.orm.xml
+++ b/src/Profile/Infrastructure/Persistence/Doctrine/Mapping/Profile.Model.Profile.orm.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                  https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Twitter\Profile\Domain\Profile\Model\Profile"
+            repository-class="Twitter\Profile\Domain\Profile\Model\ProfileRepository"
+            table="profiles">
+
+        <id name="userId" column="user_id" type="uuid">
+            <generator strategy="NONE"/>
+        </id>
+
+        <field name="name" column="name" length="60"/>
+        <field name="bio" column="bio" length="160" nullable="true"/>
+        <field name="createdAt" column="created_at" type="datetime_immutable" updatable="false"/>
+        <field name="updatedAt" column="updated_at" type="datetime_immutable"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/src/Profile/Infrastructure/Persistence/MySQL/Migration/Version20251227091316.php
+++ b/src/Profile/Infrastructure/Persistence/MySQL/Migration/Version20251227091316.php
@@ -19,8 +19,8 @@ final class Version20251227091316 extends AbstractMigration
         $this->addSql(
             <<<SQL
             CREATE TABLE profiles (
-                name VARCHAR(60) NOT NULL,
-                bio VARCHAR(160) DEFAULT NULL,
+                name VARCHAR(50) NOT NULL,
+                bio VARCHAR(300) DEFAULT NULL,
                 created_at DATETIME NOT NULL,
                 updated_at DATETIME NOT NULL,
                 user_id BINARY(16) NOT NULL,

--- a/src/Profile/Infrastructure/Persistence/MySQL/Migration/Version20251227091316.php
+++ b/src/Profile/Infrastructure/Persistence/MySQL/Migration/Version20251227091316.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Profile\Infrastructure\Persistence\MySQL\Migration;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20251227091316 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create profiles table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(
+            <<<SQL
+            CREATE TABLE profiles (
+                name VARCHAR(60) NOT NULL,
+                bio VARCHAR(160) DEFAULT NULL,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                user_id BINARY(16) NOT NULL,
+                PRIMARY KEY (user_id),
+                FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+            ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_0900_ai_ci`
+            SQL,
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE profiles');
+    }
+}

--- a/src/Profile/Infrastructure/Persistence/MySQL/Repository/MySQLProfileRepository.php
+++ b/src/Profile/Infrastructure/Persistence/MySQL/Repository/MySQLProfileRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Profile\Infrastructure\Persistence\MySQL\Repository;
+
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Exception\EntityIdentityCollisionException;
+use Twitter\Profile\Domain\Profile\Exception\ProfileAlreadyExistsException;
+use Twitter\Profile\Domain\Profile\Exception\UserNotFoundException;
+use Twitter\Profile\Domain\Profile\Model\Profile;
+use Twitter\Profile\Domain\Profile\Model\ProfileRepository;
+
+final readonly class MySQLProfileRepository implements ProfileRepository
+{
+    public function __construct(private EntityManagerInterface $entityManager) {}
+
+    /**
+     * @throws UserNotFoundException
+     * @throws ProfileAlreadyExistsException
+     */
+    public function add(Profile $profile): void
+    {
+        try {
+            $this->entityManager->persist($profile);
+            $this->entityManager->flush();
+        } catch (UniqueConstraintViolationException|EntityIdentityCollisionException) {
+            throw new ProfileAlreadyExistsException($profile->userId());
+        } catch (ForeignKeyConstraintViolationException) {
+            throw new UserNotFoundException($profile->userId());
+        }
+    }
+}

--- a/src/Profile/UI/REST/Controller/CreateProfile/CreateProfileController.php
+++ b/src/Profile/UI/REST/Controller/CreateProfile/CreateProfileController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Profile\UI\REST\Controller\CreateProfile;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+use Symfony\Component\Routing\Attribute\Route;
+use Twitter\Profile\Application\UseCase\CreateProfile\CreateProfileCommand;
+use Twitter\Profile\Application\UseCase\CreateProfile\CreateProfileCommandHandler;
+
+#[Route('/api/profiles', name: 'api_create_profile', methods: ['POST'])]
+final readonly class CreateProfileController
+{
+    public function __construct(private CreateProfileCommandHandler $handler) {}
+
+    public function __invoke(#[MapRequestPayload] CreateProfileRequest $request): Response
+    {
+        $command = new CreateProfileCommand($request->userId(), $request->name(), $request->bio());
+        $this->handler->handle($command);
+
+        return new Response(status: Response::HTTP_CREATED);
+    }
+}

--- a/src/Profile/UI/REST/Controller/CreateProfile/CreateProfileController.php
+++ b/src/Profile/UI/REST/Controller/CreateProfile/CreateProfileController.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Twitter\Profile\UI\REST\Controller\CreateProfile;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 use Symfony\Component\Routing\Attribute\Route;
 use Twitter\Profile\Application\UseCase\CreateProfile\CreateProfileCommand;
 use Twitter\Profile\Application\UseCase\CreateProfile\CreateProfileCommandHandler;
 
-#[Route('/api/profiles', name: 'api_create_profile', methods: ['POST'])]
+#[Route('/api/profiles', name: 'api_create_profile', methods: [Request::METHOD_POST])]
 final readonly class CreateProfileController
 {
     public function __construct(private CreateProfileCommandHandler $handler) {}

--- a/src/Profile/UI/REST/Controller/CreateProfile/CreateProfileRequest.php
+++ b/src/Profile/UI/REST/Controller/CreateProfile/CreateProfileRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Profile\UI\REST\Controller\CreateProfile;
+
+final readonly class CreateProfileRequest
+{
+    public function __construct(
+        private string $userId,
+        private string $name,
+        private ?string $bio = null,
+    ) {}
+
+    public function userId(): string
+    {
+        return $this->userId;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function bio(): ?string
+    {
+        return $this->bio;
+    }
+}

--- a/src/Shared/Infrastructure/EventSubscriber/ExceptionSubscriber.php
+++ b/src/Shared/Infrastructure/EventSubscriber/ExceptionSubscriber.php
@@ -17,6 +17,8 @@ use Throwable;
 use Twitter\IAM\Domain\User\Exception\InvalidEmailException;
 use Twitter\IAM\Domain\User\Exception\InvalidPasswordException;
 use Twitter\IAM\Domain\User\Exception\UserAlreadyExistsException;
+use Twitter\Profile\Domain\Profile\Exception\ProfileAlreadyExistsException;
+use Twitter\Profile\Domain\Profile\Exception\UserNotFoundException;
 
 final readonly class ExceptionSubscriber implements EventSubscriberInterface
 {
@@ -34,6 +36,16 @@ final readonly class ExceptionSubscriber implements EventSubscriberInterface
         UserAlreadyExistsException::class => [
             'code' => 'USER_ALREADY_EXISTS',
             'message' => 'A user with this email already exists',
+            'status' => Response::HTTP_CONFLICT,
+        ],
+        UserNotFoundException::class => [
+            'code' => 'USER_NOT_FOUND',
+            'message' => 'The user with this ID was not found',
+            'status' => Response::HTTP_NOT_FOUND,
+        ],
+        ProfileAlreadyExistsException::class => [
+            'code' => 'PROFILE_ALREADY_EXISTS',
+            'message' => 'A profile with this user already exists',
             'status' => Response::HTTP_CONFLICT,
         ],
     ];

--- a/tests/Profile/Application/UseCase/CreateProfile/CreateProfileCommandHandlerTest.php
+++ b/tests/Profile/Application/UseCase/CreateProfile/CreateProfileCommandHandlerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Tests\Profile\Application\UseCase\CreateProfile;
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Twitter\Profile\Application\UseCase\CreateProfile\CreateProfileCommand;
+use Twitter\Profile\Application\UseCase\CreateProfile\CreateProfileCommandHandler;
+use Twitter\Profile\Domain\Profile\Model\Profile;
+use Twitter\Profile\Domain\Profile\Model\ProfileRepository;
+
+#[Group('unit')]
+#[CoversMethod(CreateProfileCommandHandler::class, 'handle')]
+final class CreateProfileCommandHandlerTest extends TestCase
+{
+    private CreateProfileCommandHandler $handler;
+    private MockObject|ProfileRepository $profileRepository;
+
+    protected function setUp(): void
+    {
+        $this->profileRepository = $this->createMock(ProfileRepository::class);
+        $this->handler = new CreateProfileCommandHandler($this->profileRepository);
+    }
+
+    #[Test]
+    public function testHandleWithValidCommand(): void
+    {
+        $command = new CreateProfileCommand(
+            userId: '019b5f3f-d110-7908-9177-5df439942a8b',
+            name: 'John Doe',
+            bio: 'Software Developer'
+        );
+
+        $this->profileRepository
+            ->expects(self::once())
+            ->method('add')
+            ->with(self::callback(function (Profile $profile) use ($command) {
+                return $profile->userId() === $command->userId &&
+                    $profile->name() === $command->name &&
+                    $profile->bio() === $command->bio;
+            }));
+
+        $this->handler->handle($command);
+    }
+
+    #[Test]
+    public function testHandleWithNullBio(): void
+    {
+        $command = new CreateProfileCommand(
+            userId: '019b5f3f-d110-7908-9177-5df439942a8b',
+            name: 'Jane Doe',
+            bio: null
+        );
+
+        $this->profileRepository
+            ->expects(self::once())
+            ->method('add')
+            ->with(self::callback(function (Profile $profile) use ($command) {
+                return $profile->userId() === $command->userId &&
+                    $profile->name() === $command->name &&
+                    $profile->bio() === '';
+            }));
+
+        $this->handler->handle($command);
+    }
+}

--- a/tests/Profile/Application/UseCase/CreateProfile/CreateProfileCommandHandlerTest.php
+++ b/tests/Profile/Application/UseCase/CreateProfile/CreateProfileCommandHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Twitter\Tests\Profile\Application\UseCase\CreateProfile;
 
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -11,6 +12,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Twitter\Profile\Application\UseCase\CreateProfile\CreateProfileCommand;
 use Twitter\Profile\Application\UseCase\CreateProfile\CreateProfileCommandHandler;
+use Twitter\Profile\Domain\Profile\Exception\ProfileAlreadyExistsException;
+use Twitter\Profile\Domain\Profile\Exception\UserNotFoundException;
 use Twitter\Profile\Domain\Profile\Model\Profile;
 use Twitter\Profile\Domain\Profile\Model\ProfileRepository;
 
@@ -28,43 +31,92 @@ final class CreateProfileCommandHandlerTest extends TestCase
     }
 
     #[Test]
-    public function testHandleWithValidCommand(): void
+    public function handleCreatesProfileWithProvidedData(): void
     {
+        $userId = '019b5f3f-d110-7908-9177-5df439942a8b';
+        $name = 'John Doe';
+        $bio = 'Software Developer';
+
         $command = new CreateProfileCommand(
-            userId: '019b5f3f-d110-7908-9177-5df439942a8b',
-            name: 'John Doe',
-            bio: 'Software Developer'
+            userId: $userId,
+            name: $name,
+            bio: $bio
         );
 
         $this->profileRepository
             ->expects(self::once())
             ->method('add')
-            ->with(self::callback(function (Profile $profile) use ($command) {
-                return $profile->userId() === $command->userId &&
-                    $profile->name() === $command->name &&
-                    $profile->bio() === $command->bio;
-            }));
+            ->with(self::callback(
+                fn (Profile $profile): bool => $userId === $profile->userId()
+                    && $name === $profile->name()
+                    && $bio === $profile->bio()
+            ));
 
         $this->handler->handle($command);
     }
 
     #[Test]
-    public function testHandleWithNullBio(): void
+    public function handleCreatesProfileWithEmptyBioWhenNullProvided(): void
     {
+        $userId = '019b5f3f-d110-7908-9177-5df439942a8b';
+        $name = 'John Doe';
+
         $command = new CreateProfileCommand(
-            userId: '019b5f3f-d110-7908-9177-5df439942a8b',
-            name: 'Jane Doe',
+            userId: $userId,
+            name: $name,
             bio: null
         );
 
         $this->profileRepository
             ->expects(self::once())
             ->method('add')
-            ->with(self::callback(function (Profile $profile) use ($command) {
-                return $profile->userId() === $command->userId &&
-                    $profile->name() === $command->name &&
-                    $profile->bio() === '';
-            }));
+            ->with(self::callback(
+                fn (Profile $profile): bool => $userId === $profile->userId()
+                    && $name === $profile->name()
+                    && '' === $profile->bio()
+            ));
+
+        $this->handler->handle($command);
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function handlePropagatesProfileAlreadyExistsException(): void
+    {
+        $userId = '019b5f3f-d110-7908-9177-5df439942a8b';
+
+        $command = new CreateProfileCommand(
+            userId: $userId,
+            name: 'John Doe',
+            bio: null
+        );
+
+        $this->profileRepository
+            ->method('add')
+            ->willThrowException(new ProfileAlreadyExistsException($userId));
+
+        $this->expectException(ProfileAlreadyExistsException::class);
+
+        $this->handler->handle($command);
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function handlePropagatesUserNotFoundException(): void
+    {
+        $userId = '019b5f3f-d110-7908-9177-5df439942a8b';
+
+        $command = new CreateProfileCommand(
+            userId: $userId,
+            name: 'John Doe',
+            bio: null
+        );
+
+        $this->profileRepository
+            ->method('add')
+            ->willThrowException(new UserNotFoundException($userId));
+
+        $this->expectException(UserNotFoundException::class);
 
         $this->handler->handle($command);
     }

--- a/tests/Profile/Domain/Profile/Model/ProfileTest.php
+++ b/tests/Profile/Domain/Profile/Model/ProfileTest.php
@@ -79,11 +79,11 @@ final class ProfileTest extends TestCase
     {
         yield 'empty value' => [''];
         yield 'less then 3 characters long' => ['Jo'];
-        yield 'more then 60 characters long' => [str_repeat('a', 61)];
+        yield 'more then 50 characters long' => [str_repeat('a', 51)];
     }
 
     public static function invalidBioProvider(): Generator
     {
-        yield 'more then 160 characters long' => [str_repeat('b', 161)];
+        yield 'more then 300 characters long' => [str_repeat('b', 301)];
     }
 }

--- a/tests/Profile/Domain/Profile/Model/ProfileTest.php
+++ b/tests/Profile/Domain/Profile/Model/ProfileTest.php
@@ -1,9 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Twitter\Tests\Profile\Domain\Profile\Model;
 
-use Assert\InvalidArgumentException;
+use Assert\LazyAssertionException;
+use Generator;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -13,11 +17,8 @@ use Twitter\Profile\Domain\Profile\Model\Profile;
 #[CoversClass(Profile::class)]
 final class ProfileTest extends TestCase
 {
-    /**
-     * Test that a valid Profile object can be successfully created.
-     */
     #[Test]
-    public function createValidProfile(): void
+    public function createsProfileWithValidData(): void
     {
         $userId = '019b5f3f-d110-7908-9177-5df439942a8b';
         $name = 'John Doe';
@@ -32,11 +33,8 @@ final class ProfileTest extends TestCase
         $this->assertNotNull($profile->updatedAt());
     }
 
-    /**
-     * Test that a Profile object can be created without a bio.
-     */
     #[Test]
-    public function createWithoutBio(): void
+    public function createsProfileWithoutBio(): void
     {
         $userId = '019b5f3f-d110-7908-9177-5df439942a8b';
         $name = 'Jane Doe';
@@ -46,60 +44,48 @@ final class ProfileTest extends TestCase
         $this->assertSame('', $profile->bio());
     }
 
-    /**
-     * Test that creating a Profile with an invalid UUID throws an exception.
-     */
     #[Test]
-    public function createInvalidUserId(): void
+    #[DataProvider('invalidUserIdProvider')]
+    public function rejectsInvalidUserId(string $userId): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(LazyAssertionException::class);
 
-        Profile::create('invalid-uuid', 'John Doe');
+        Profile::create($userId, 'John Doe');
     }
 
-    /**
-     * Test that creating a Profile with a blank name throws an exception.
-     */
     #[Test]
-    public function createBlankName(): void
+    #[DataProvider('invalidNameProvider')]
+    public function rejectsInvalidName(string $name): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(LazyAssertionException::class);
 
-        Profile::create('019b5f3f-d110-7908-9177-5df439942a8b', '');
-    }
-
-    /**
-     * Test that creating a Profile with a name shorter than 3 characters throws an exception.
-     */
-    #[Test]
-    public function createShortName(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        Profile::create('019b5f3f-d110-7908-9177-5df439942a8b', 'Jo');
-    }
-
-    /**
-     * Test that creating a Profile with a name longer than 60 characters throws an exception.
-     */
-    #[Test]
-    public function createLongName(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        $name = str_repeat('a', 61);
         Profile::create('019b5f3f-d110-7908-9177-5df439942a8b', $name);
     }
 
-    /**
-     * Test that creating a Profile with a bio longer than 160 characters throws an exception.
-     */
     #[Test]
-    public function createLongBio(): void
+    #[DataProvider('invalidBioProvider')]
+    public function rejectsInvalidBio(string $bio): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(LazyAssertionException::class);
 
-        $bio = str_repeat('b', 161);
-        Profile::create('019b5f3f-d110-7908-9177-5df439942a8b', 'John Doe', $bio);
+        Profile::create('019b5f3f-d110-7908-9177-5df439942a8b', 'Jo', $bio);
+    }
+
+    public static function invalidUserIdProvider(): Generator
+    {
+        yield 'invalid uuid' => ['invalid-uuid'];
+        yield 'empty value' => [''];
+    }
+
+    public static function invalidNameProvider(): Generator
+    {
+        yield 'empty value' => [''];
+        yield 'less then 3 characters long' => ['Jo'];
+        yield 'more then 60 characters long' => [str_repeat('a', 61)];
+    }
+
+    public static function invalidBioProvider(): Generator
+    {
+        yield 'more then 160 characters long' => [str_repeat('b', 161)];
     }
 }

--- a/tests/Profile/Domain/Profile/Model/ProfileTest.php
+++ b/tests/Profile/Domain/Profile/Model/ProfileTest.php
@@ -29,8 +29,6 @@ final class ProfileTest extends TestCase
         $this->assertSame($userId, $profile->userId());
         $this->assertSame($name, $profile->name());
         $this->assertSame($bio, $profile->bio());
-        $this->assertNotNull($profile->createdAt());
-        $this->assertNotNull($profile->updatedAt());
     }
 
     #[Test]

--- a/tests/Profile/Domain/Profile/Model/ProfileTest.php
+++ b/tests/Profile/Domain/Profile/Model/ProfileTest.php
@@ -66,7 +66,7 @@ final class ProfileTest extends TestCase
     {
         $this->expectException(LazyAssertionException::class);
 
-        Profile::create('019b5f3f-d110-7908-9177-5df439942a8b', 'Jo', $bio);
+        Profile::create('019b5f3f-d110-7908-9177-5df439942a8b', 'John Doe', $bio);
     }
 
     public static function invalidUserIdProvider(): Generator

--- a/tests/Profile/Domain/Profile/Model/ProfileTest.php
+++ b/tests/Profile/Domain/Profile/Model/ProfileTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Twitter\Tests\Profile\Domain\Profile\Model;
+
+use Assert\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Twitter\Profile\Domain\Profile\Model\Profile;
+
+#[Group('unit')]
+#[CoversClass(Profile::class)]
+final class ProfileTest extends TestCase
+{
+    /**
+     * Test that a valid Profile object can be successfully created.
+     */
+    #[Test]
+    public function createValidProfile(): void
+    {
+        $userId = '019b5f3f-d110-7908-9177-5df439942a8b';
+        $name = 'John Doe';
+        $bio = 'This is a sample bio';
+
+        $profile = Profile::create($userId, $name, $bio);
+
+        $this->assertSame($userId, $profile->userId());
+        $this->assertSame($name, $profile->name());
+        $this->assertSame($bio, $profile->bio());
+        $this->assertNotNull($profile->createdAt());
+        $this->assertNotNull($profile->updatedAt());
+    }
+
+    /**
+     * Test that a Profile object can be created without a bio.
+     */
+    #[Test]
+    public function createWithoutBio(): void
+    {
+        $userId = '019b5f3f-d110-7908-9177-5df439942a8b';
+        $name = 'Jane Doe';
+
+        $profile = Profile::create($userId, $name);
+
+        $this->assertSame('', $profile->bio());
+    }
+
+    /**
+     * Test that creating a Profile with an invalid UUID throws an exception.
+     */
+    #[Test]
+    public function createInvalidUserId(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Profile::create('invalid-uuid', 'John Doe');
+    }
+
+    /**
+     * Test that creating a Profile with a blank name throws an exception.
+     */
+    #[Test]
+    public function createBlankName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Profile::create('019b5f3f-d110-7908-9177-5df439942a8b', '');
+    }
+
+    /**
+     * Test that creating a Profile with a name shorter than 3 characters throws an exception.
+     */
+    #[Test]
+    public function createShortName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Profile::create('019b5f3f-d110-7908-9177-5df439942a8b', 'Jo');
+    }
+
+    /**
+     * Test that creating a Profile with a name longer than 60 characters throws an exception.
+     */
+    #[Test]
+    public function createLongName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $name = str_repeat('a', 61);
+        Profile::create('019b5f3f-d110-7908-9177-5df439942a8b', $name);
+    }
+
+    /**
+     * Test that creating a Profile with a bio longer than 160 characters throws an exception.
+     */
+    #[Test]
+    public function createLongBio(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $bio = str_repeat('b', 161);
+        Profile::create('019b5f3f-d110-7908-9177-5df439942a8b', 'John Doe', $bio);
+    }
+}


### PR DESCRIPTION
**Jira**: [SCRUM-52](https://epam-team-php.atlassian.net/browse/SCRUM-52)

## Description

Introduce a user profile creation endpoint.

## How to roll back?

- Rollback migrations:
  
  ```shell
  docker compose exec php php bin/console doctrine:migrations:execute --no-interaction --down "Twitter\\Profile\\Infrastructure\\Persistence\\MySQL\\Migrations\\Version20251227091316"
  ```
- Revert this pull request

## How has this been tested?

Unit tests cover domain and application layers.

To reproduce, run:

```shell
docker compose exec php ./vendor/bin/phpunit tests/Profile --display-all-issues --testdox --group unit
```

You should see the following output with all tests passed:

```
PHPUnit 12.5.4 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.16
Configuration: /app/phpunit.dist.xml

............              12 / 12 (100%)

Time: 00:00.008, Memory: 16.00 MB

Create Profile Command Handler (Twitter\Tests\Profile\Application\UseCase\CreateProfile\CreateProfileCommandHandler)
 ✔ Handle creates profile with provided data
 ✔ Handle creates profile with empty bio when null provided
 ✔ Handle propagates profile already exists exception
 ✔ Handle propagates user not found exception

Profile (Twitter\Tests\Profile\Domain\Profile\Model\Profile)
 ✔ Creates profile with valid data
 ✔ Creates profile without bio
 ✔ Rejects invalid user id with data set "invalid uuid"
 ✔ Rejects invalid user id with data set "empty value"
 ✔ Rejects invalid name with data set "empty value"
 ✔ Rejects invalid name with data set "less then 3 characters long"
 ✔ Rejects invalid name with data set "more then 50 characters long"
 ✔ Rejects invalid bio with data set "more then 300 characters long"

OK (12 tests, 16 assertions)
```

## Media attachments

### Manually tested cases

All fields are valid:

<img width="1254" height="779" alt="Screenshot 2025-12-27 114347" src="https://github.com/user-attachments/assets/d5231155-a9e4-4147-b4d1-9439f7004c01" />

Bio is optional, so it can be left unspecified:

<img width="1364" height="821" alt="Screenshot 2025-12-27 121249" src="https://github.com/user-attachments/assets/7a43e797-b113-4634-9d43-92f1f47a38a1" />

The user already has a profile:

<img width="1278" height="779" alt="Screenshot 2025-12-27 114414" src="https://github.com/user-attachments/assets/16793489-f5f1-4401-ac0c-1e9a900464dd" />

The user ID is invalid:

<img width="1253" height="779" alt="Screenshot 2025-12-27 114434" src="https://github.com/user-attachments/assets/4bf9dcf5-5fa3-4f94-b1e8-37e1ad950db3" />

The name is too short:

<img width="1253" height="779" alt="Screenshot 2025-12-27 114514" src="https://github.com/user-attachments/assets/94aaa5af-b354-4c4d-86f5-fa74618d161a" />

The name is too long:

<img width="1364" height="821" alt="Screenshot 2025-12-27 120436" src="https://github.com/user-attachments/assets/b325ca9b-f9f1-45ff-8774-1cdbd514217a" />

The bio is too long:

<img width="1265" height="779" alt="Screenshot 2025-12-27 114631" src="https://github.com/user-attachments/assets/bc5023d4-77f9-45de-a0fb-0452e138a45a" />

Multiple fields are invalid:

<img width="1364" height="821" alt="Screenshot 2025-12-27 115304" src="https://github.com/user-attachments/assets/8c7a98b5-fb07-4ec5-8975-a0ebc1bc6652" />
