### PR TITLE
feat(tweet): SCRUM-98 Resolve Null Pointer Error on Single Tweet Page

### DIFF
--- a/config/reference.php
+++ b/config/reference.php
@@ -1514,8 +1514,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type MercureConfig = array{
  *     hubs?: array<string, array{ // Default: []
- *         url?: scalar|Param|null, // URL of the hub's publish endpoint
- *         public_url?: scalar|Param|null, // URL of the hub's public endpoint // Default: null
+ *         url?: scalar|Param|null, // URL of the hub's publish endpoint // Default: null
+ *         public_url?: scalar|Param|null, // URL of the hub's public endpoint
  *         jwt?: string|array{ // JSON Web Token configuration.
  *             value?: scalar|Param|null, // JSON Web Token to use to publish to this hub.
  *             provider?: scalar|Param|null, // The ID of a service to call to provide the JSON Web Token.

--- a/public/js/tweet.js
+++ b/public/js/tweet.js
@@ -8,7 +8,7 @@ async function getTweet(tweetId) {
     });
 
     if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
+      return null;
     }
 
     const data = await response.json();
@@ -17,6 +17,7 @@ async function getTweet(tweetId) {
     return data;
   } catch (error) {
     console.error('Error:', error);
+    return null;
   }
 }
 

--- a/public/js/tweet.js
+++ b/public/js/tweet.js
@@ -68,10 +68,10 @@ function showTweet(tweet) {
   document.querySelector('[tweet_createdAt]').textContent = ' · ' + formatPublishDate(tweet.createdAt);
   document.querySelector('[data-tweet-content]').textContent = tweet.content;
   document.querySelector('[tweet_likes]').textContent = tweet.likesCount;
-  document.querySelector("div.tweet-actions > div > button.tweet-like-btn").setAttribute('data-tweet-id', tweet.id);
-  document.querySelector("div > div.tweet-edit-form > div").setAttribute('data-tweet-id', tweet.id);
-  document.querySelector("div > button.btn.tweet-edit-btn").setAttribute('data-tweet-id', tweet.id);
-  document.querySelector("div > button.btn.tweet-edit-btn").setAttribute('data-author-id', tweet.author.id);
+  document.querySelector(".tweet-like-btn").setAttribute('data-tweet-id', tweet.id);
+  document.querySelector(".tweet-form-container").setAttribute('data-tweet-id', tweet.id);
+  document.querySelector(".tweet-edit-btn").setAttribute('data-tweet-id', tweet.id);
+  document.querySelector(".tweet-edit-btn").setAttribute('data-author-id', tweet.author.id);
 
   document.querySelector('.tweet').style.visibility = 'visible';
 

--- a/src/Profile/UI/Web/ProfilePage/ProfilePageController.php
+++ b/src/Profile/UI/Web/ProfilePage/ProfilePageController.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Twitter\Profile\UI\Web\ProfilePage;
 
 use Assert\Assert;
+use Assert\AssertionFailedException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Twitter\Profile\Application\UseCase\GetProfile\GetProfileQuery;
 use Twitter\Profile\Application\UseCase\GetProfile\GetProfileQueryHandler;
@@ -24,9 +26,17 @@ final class ProfilePageController extends AbstractController
      */
     public function __invoke(string $userId): Response
     {
-        Assert::that($userId)->uuid();
+        try {
+            Assert::that($userId)->uuid();
+        } catch (AssertionFailedException) {
+            throw new NotFoundHttpException('Profile not found.');
+        }
 
-        $profileResult = $this->profileQueryHandler->handle(new GetProfileQuery($userId));
+        try {
+            $profileResult = $this->profileQueryHandler->handle(new GetProfileQuery($userId));
+        } catch (ProfileNotFoundException) {
+            throw new NotFoundHttpException('Profile not found.');
+        }
 
         return $this->render('page/profile.html.twig', [
             'profile' => [

--- a/templates/bundles/TwigBundle/Exception/error.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error.html.twig
@@ -1,0 +1,24 @@
+{% extends 'layout/base.html.twig' %}
+
+{% block title %}Error{% endblock %}
+
+{% block content %}
+    <div class="p-4 text-center">
+        <div class="mb-2 text-muted" style="font-size: 3rem; font-weight: 700; line-height: 1;">
+            {{ status_code|default(500) }}
+        </div>
+
+        <div class="mb-2">
+            <span class="text-muted">Something went wrong.</span>
+        </div>
+
+        {% if status_text is defined and status_text %}
+            <div class="text-muted small mb-3">
+                {{ status_text }}
+            </div>
+        {% endif %}
+
+        <a href="{{ path('homepage') }}" class="btn btn-outline-primary">Go Home</a>
+    </div>
+{% endblock %}
+

--- a/templates/bundles/TwigBundle/Exception/error404.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error404.html.twig
@@ -1,0 +1,22 @@
+{% extends 'layout/base.html.twig' %}
+
+{% block title %}404 - Not Found{% endblock %}
+
+{% block content %}
+    <div class="p-4 text-center">
+        <div class="mb-2 text-muted" style="font-size: 3rem; font-weight: 700; line-height: 1;">
+            404
+        </div>
+
+        <div class="mb-2">
+            <span class="text-muted">Page not found.</span>
+        </div>
+
+        <div class="text-muted small mb-3">
+            The page you're looking for doesn't exist or has been moved.
+        </div>
+
+        <a href="{{ path('homepage') }}" class="btn btn-outline-primary">Go Home</a>
+    </div>
+{% endblock %}
+

--- a/templates/page/tweetpage.html.twig
+++ b/templates/page/tweetpage.html.twig
@@ -4,6 +4,17 @@
 
 {% block content %}
 
+    <div id="tweet-error" class="p-4 text-center" style="display: none;">
+        <div class="mb-2 text-muted" id="tweet-error-status" style="font-size: 3rem; font-weight: 700; line-height: 1;">
+            404
+        </div>
+        <p class="text-muted mb-1" id="tweet-error-message">Tweet not found</p>
+        <p class="text-muted small mb-3" id="tweet-error-details">
+            The tweet you're looking for doesn't exist or has been deleted.
+        </p>
+        <a href="{{ path('homepage') }}" class="btn btn-outline-primary mt-1">Go Home</a>
+    </div>
+
     <div class="tweet p-3 border-bottom" style="visibility: hidden;">
         <div class="d-flex align-items-center mb-1">
             <span class="fw-bold me-2" tweet_author>{ tweet.author.name }</span>
@@ -76,7 +87,15 @@
             const tweetId = window.location.pathname.replace('/t/', '');
             console.log('tweetId: ', tweetId);
             const tweetData = await getTweet(tweetId);
-            showTweet(tweetData);
+            if (tweetData) {
+                showTweet(tweetData);
+                return;
+            }
+
+            const errorBlock = document.getElementById('tweet-error');
+            if (errorBlock) {
+                errorBlock.style.display = 'block';
+            }
         });
     </script>
     <script src="{{ asset('js/alert.js') }}"></script>


### PR DESCRIPTION
**Jira**: [SCRUM-98](https://epam-team-php.atlassian.net/browse/SCRUM-98)

## Description

Viewing a single tweet page resulted in a `TypeError: Cannot read properties of null (reading 'setAttribute')` for both authorized and unauthorized users. The root cause was in `public/js/tweet.js` lines 71-74, where the `showTweet()` function used overly specific CSS selectors (e.g., `"div.tweet-actions > div > button.tweet-like-btn"`) that didn't match the actual DOM structure in `templates/page/tweetpage.html.twig`. This caused `querySelector()` to return `null`, resulting in an error when attempting to set attributes.

The solution was to simplify the selectors to target elements by their unique class names. These class-based selectors reliably match the elements present in the template regardless of their parent hierarchy.

## How to roll back?

Revert this pull request.

## How has this been tested?

Manually tested.

## Media attachments

How the issue looked before fixes:

https://github.com/user-attachments/assets/300b1e87-52f0-4552-9d6c-9ef7a7ab7cde
