### PR TITLE
fix(database): SCRUM-19 Optimize Feed Queries

### DIFF
--- a/src/Profile/Domain/Profile/Model/ProfileRepository.php
+++ b/src/Profile/Domain/Profile/Model/ProfileRepository.php
@@ -16,4 +16,6 @@ interface ProfileRepository
      * @throws ProfileNotFoundException
      */
     public function getByUserId(string $userId): Profile;
+
+    public function findAllByUserIds(array $userIds): array;
 }

--- a/src/Profile/Infrastructure/Persistence/MySQL/Repository/MySQLProfileRepository.php
+++ b/src/Profile/Infrastructure/Persistence/MySQL/Repository/MySQLProfileRepository.php
@@ -55,4 +55,15 @@ final readonly class MySQLProfileRepository implements ProfileRepository
 
         return $profile;
     }
+
+    public function findAllByUserIds(array $userIds): array
+    {
+        return $this->entityManager->createQueryBuilder()
+            ->select('p')
+            ->from(Profile::class, 'p')
+            ->where('p.userId IN (:userIds)')
+            ->setParameter('userIds', $userIds)
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/Tweet/Application/UseCase/GetTweets/GetTweetsCommandHandler.php
+++ b/src/Tweet/Application/UseCase/GetTweets/GetTweetsCommandHandler.php
@@ -18,9 +18,19 @@ final readonly class GetTweetsCommandHandler
     public function handle(GetTweetsCommand $command): GetTweetsResponse
     {
         $tweets = $this->tweetRepository->getAllTweets($command->limit, $command->page);
+        $tweetResponses = [];
+
+        if ([] === $tweets) {
+            return new GetTweetsResponse($tweetResponses);
+        }
+
+        $userIds = array_values(array_unique(array_map(static fn ($tweet) => $tweet->userId(), $tweets)));
+        $profiles = $this->profileRepository->findAllByUserIds($userIds);
 
         $authorNameById = [];
-        $tweetResponses = [];
+        foreach ($profiles as $profile) {
+            $authorNameById[$profile->userId()] = $profile->name();
+        }
 
         foreach ($tweets as $tweet) {
             $authorId = $tweet->userId();

--- a/tests/Tweet/Application/UseCase/GetTweets/GetTweetsCommandHandlerTest.php
+++ b/tests/Tweet/Application/UseCase/GetTweets/GetTweetsCommandHandlerTest.php
@@ -71,12 +71,14 @@ final class GetTweetsCommandHandlerTest extends TestCase
             ->willReturn([$tweetNewest, $tweetOldest]);
 
         $this->profileRepository
-            ->expects(self::exactly(2))
-            ->method('getByUserId')
-            ->willReturnMap([
-                [$authorIdOne, $profileOne],
-                [$authorIdTwo, $profileTwo],
-            ]);
+            ->expects(self::once())
+            ->method('findAllByUserIds')
+            ->with($this->callback(function (array $userIds) use ($authorIdOne, $authorIdTwo) {
+                return 2 === count($userIds)
+                    && in_array($authorIdOne, $userIds, true)
+                    && in_array($authorIdTwo, $userIds, true);
+            }))
+            ->willReturn([$profileOne, $profileTwo]);
 
         $result = $this->handler->handle(new GetTweetsCommand());
 
@@ -116,9 +118,9 @@ final class GetTweetsCommandHandlerTest extends TestCase
 
         $this->profileRepository
             ->expects(self::once())
-            ->method('getByUserId')
-            ->with($authorId)
-            ->willReturn($profile);
+            ->method('findAllByUserIds')
+            ->with([$authorId])
+            ->willReturn([$profile]);
 
         $result = $this->handler->handle(new GetTweetsCommand());
 


### PR DESCRIPTION
**Jira**: [SCRUM-19](https://epam-team-php.atlassian.net/browse/SCRUM-19)

## Description

Optimize Feed Queries (N+1 Problem)

## How to roll back?

Revert this pull request.

## How has this been tested?

<pre><font color="#586E75"><b>illia@honor-magicbook-x-15</b></font>:<font color="#839496"><b>~/PhpstormProjects/Twitter</b></font>$ docker compose exec php ./vendor/bin/phpunit tests/Tweet/Application/UseCase/GetTweets --display-all-issues --testdox --group unit
PHPUnit 12.5.6 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.17
Configuration: /app/phpunit.dist.xml

...                                                                 3 / 3 (100%)

Time: 00:00.015, Memory: 16.00 MB

<u style="text-decoration-style:solid">Get Tweets Command Handler (Twitter\Tests\Tweet\Application\UseCase\GetTweets\GetTweetsCommandHandler)</u>
<font color="#859900"> ✔ </font>It returns empty list when no tweets exist
<font color="#859900"> ✔ </font>It returns tweets with author data in same order
<font color="#859900"> ✔ </font>It fetches author name only once per author id

<span style="background-color:#859900"><font color="#073642">OK (3 tests, 27 assertions)</font></span></pre>

## Media attachments (optional)
