### PR TITLE
feat(registration): SCRUM-84 Add Atomic Registration API Endpoint

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -35,6 +35,7 @@ security:
         - { path: ^/api/token, roles: PUBLIC_ACCESS }
         - { path: ^/api/health, roles: PUBLIC_ACCESS }
         - { path: ^/api/users, roles: PUBLIC_ACCESS }
+        - { path: ^/api/registration, roles: PUBLIC_ACCESS }
         - { path: ^/api/profiles, methods: [GET], roles: PUBLIC_ACCESS }
         - { path: ^/api/tweets, methods: [GET], roles: PUBLIC_ACCESS }
         - { path: ^/api/tokens, roles: PUBLIC_ACCESS }

--- a/config/reference.php
+++ b/config/reference.php
@@ -1514,8 +1514,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type MercureConfig = array{
  *     hubs?: array<string, array{ // Default: []
- *         url?: scalar|Param|null, // URL of the hub's publish endpoint // Default: null
- *         public_url?: scalar|Param|null, // URL of the hub's public endpoint
+ *         url?: scalar|Param|null, // URL of the hub's publish endpoint
+ *         public_url?: scalar|Param|null, // URL of the hub's public endpoint // Default: null
  *         jwt?: string|array{ // JSON Web Token configuration.
  *             value?: scalar|Param|null, // JSON Web Token to use to publish to this hub.
  *             provider?: scalar|Param|null, // The ID of a service to call to provide the JSON Web Token.

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -8,6 +8,10 @@ iam_module:
     resource: ../src/IAM/UI/REST/Controller/
     type: attribute
 
+registration_module:
+    resource: ../src/Registration/UI/REST/Controller/
+    type: attribute
+
 iam_module_web:
     resource: ../src/IAM/UI/Web/*/*Controller.php
     type: attribute

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -25,9 +25,17 @@ services:
         resource: '../src/IAM/UI/Web/*/*Controller.php'
         tags: [ 'controller.service_arguments' ]
 
+    Twitter\Registration\UI\REST\Controller\:
+        resource: '../src/Registration/UI/REST/Controller/*Controller.php'
+        tags: [ 'controller.service_arguments' ]
+
     Twitter\IAM\Application\CreateUser\CreateUserCommandHandler:
         arguments:
             $userRepository: '@Twitter\IAM\Domain\User\Model\UserRepository'
+
+    Twitter\Registration\Application\UseCase\RegisterUser\RegisterUserCommandHandler:
+        arguments:
+            $entityManager: '@doctrine.orm.entity_manager'
 
     Twitter\IAM\Application\Logout\LogoutHandler:
         arguments:

--- a/public/js/alert.js
+++ b/public/js/alert.js
@@ -14,4 +14,44 @@ window.Alert = {
     `;
     container.append(wrapper);
   },
+
+  appendValidationErrors(container, errors, title = "Please fix the following:") {
+    container.replaceChildren();
+
+    const wrapper = document.createElement("div");
+    const alert = document.createElement("div");
+    alert.className = "alert alert-danger";
+    alert.setAttribute("role", "alert");
+
+    const titleEl = document.createElement("div");
+    titleEl.textContent = title;
+    alert.appendChild(titleEl);
+
+    const list = document.createElement("ul");
+    list.className = "mb-0 mt-2";
+
+    (Array.isArray(errors) ? errors : []).forEach((e) => {
+      const li = document.createElement("li");
+
+      const strong = document.createElement("strong");
+      strong.textContent = `${e?.field ?? "field"}: `;
+      li.appendChild(strong);
+
+      li.appendChild(document.createTextNode(String(e?.message ?? "")));
+      list.appendChild(li);
+    });
+
+    alert.appendChild(list);
+    wrapper.appendChild(alert);
+    container.append(wrapper);
+  },
+
+  appendApiError(container, error, fallbackMessage = "An error occurred") {
+    if (error?.errors && Array.isArray(error.errors) && error.errors.length > 0) {
+      this.appendValidationErrors(container, error.errors);
+      return;
+    }
+
+    this.append(container, error?.message || fallbackMessage, "danger");
+  },
 };

--- a/public/js/api.js
+++ b/public/js/api.js
@@ -1,3 +1,17 @@
+class ApiError extends Error {
+  constructor(message, { code = null, errors = null, status = 0 } = {}) {
+    super(message);
+    this.name = 'ApiError';
+    this.code = code;
+    this.errors = errors;
+    this.status = status;
+  }
+
+  isValidationError() {
+    return Array.isArray(this.errors) && this.errors.length > 0;
+  }
+}
+
 window.Api = {
   /**
    * In-flight refresh promise to prevent concurrent refresh attempts
@@ -398,7 +412,14 @@ window.Api = {
     const data = await response.json().catch(() => null);
 
     if (!response.ok) {
-      throw new Error(data?.error?.message ?? data?.message ?? response.statusText);
+      throw new ApiError(
+        data?.error?.message ?? data?.message ?? response.statusText,
+        {
+          code: data?.error?.code ?? null,
+          errors: data?.errors ?? null,
+          status: response.status
+        }
+      );
     }
 
     return data;
@@ -419,7 +440,14 @@ window.Api = {
     const data = await response.json().catch(() => null);
 
     if (!response.ok) {
-      throw new Error(data?.error?.message ?? data?.message ?? response.statusText);
+      throw new ApiError(
+        data?.error?.message ?? data?.message ?? response.statusText,
+        {
+          code: data?.error?.code ?? null,
+          errors: data?.errors ?? null,
+          status: response.status
+        }
+      );
     }
 
     return data;
@@ -445,7 +473,14 @@ window.Api = {
     const data = await response.json().catch(() => null);
 
     if (!response.ok) {
-      throw new Error(data?.error?.message ?? data?.message ?? response.statusText);
+      throw new ApiError(
+        data?.error?.message ?? data?.message ?? response.statusText,
+        {
+          code: data?.error?.code ?? null,
+          errors: data?.errors ?? null,
+          status: response.status
+        }
+      );
     }
 
     return data;

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -28,7 +28,13 @@ document.addEventListener('DOMContentLoaded', () => {
       Alert.append(alerts, 'You have been successfully logged in!', 'success');
       window.location.href = window.routes.successRedirect;
     } catch (e) {
-      Alert.append(alerts, 'Login failed', 'danger');
+      if (e?.isValidationError?.()) {
+        Alert.appendValidationErrors(alerts, e.errors);
+      } else if (e?.status === 401) {
+        Alert.append(alerts, 'Invalid email or password. Please try again.', 'danger');
+      } else {
+        Alert.append(alerts, e?.message || 'Login failed. Please try again.', 'danger');
+      }
     }
   });
 });

--- a/public/js/profile.js
+++ b/public/js/profile.js
@@ -113,7 +113,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         Alert.append(alerts, "Profile updated successfully!", "success");
       } catch (error) {
         Loading.hide(alerts);
-        Alert.append(alerts, error.message || "Failed to update profile", "danger");
+        Alert.appendApiError(alerts, error, "Failed to update profile");
       } finally {
         Loading.enableForm(profileEditForm);
       }

--- a/public/js/registration.js
+++ b/public/js/registration.js
@@ -44,7 +44,21 @@ document.addEventListener("DOMContentLoaded", () => {
       window.location.href = window.routes.successRedirect;
     } catch (e) {
       Loading.hide(alerts);
-      Alert.append(alerts, "Registration failed", "danger");
+      if (e?.code === "USER_ALREADY_EXISTS") {
+        Alert.append(
+          alerts,
+          "An account with this email already exists. Try logging in instead.",
+          "warning"
+        );
+      } else if (e?.isValidationError?.()) {
+        Alert.appendValidationErrors(alerts, e.errors, "Please fix the following errors:");
+      } else {
+        Alert.append(
+          alerts,
+          e?.message || "Registration failed. Please try again.",
+          "danger"
+        );
+      }
     } finally {
       Loading.enableForm(form);
     }

--- a/public/js/registration.js
+++ b/public/js/registration.js
@@ -11,15 +11,17 @@ document.addEventListener("DOMContentLoaded", () => {
       Loading.clearAndShow(alerts, "Registering...");
       Loading.disableForm(form);
 
-      const user = await Api.post(window.routes.createUser, {
+      await Api.post(window.routes.registerUser, {
         email: data.email,
         password: data.password,
-      });
+        name: data.name,
+        bio: data.bio,
+      }, { skipAuth: true });
 
       const auth = await Api.post(window.routes.login, {
         email: data.email,
         password: data.password,
-      });
+      }, { skipAuth: true });
 
       // Handle both token and accessToken response formats
       const accessToken = auth.token || auth.accessToken;
@@ -36,11 +38,6 @@ document.addEventListener("DOMContentLoaded", () => {
       if (refreshToken) {
         Api.setRefreshToken(refreshToken);
       }
-
-      await Api.post(
-        window.routes.createProfile,
-        { userId: user.id, name: data.name, bio: data.bio }
-      );
 
       Loading.hide(alerts);
       Alert.append(alerts, "You have been successfully registered!", "success");

--- a/public/js/tweets.js
+++ b/public/js/tweets.js
@@ -32,6 +32,10 @@ function initializeTweetCharCounter(container) {
 }
 
 function normalizeError(error) {
+  if (error?.errors && Array.isArray(error.errors) && error.errors.length > 0) {
+    return error.errors.map((e) => e?.message).filter(Boolean).join(". ");
+  }
+
   const message = String(error?.message || "");
   return message || "Failed to post tweet";
 }

--- a/src/Registration/Application/UseCase/RegisterUser/RegisterUserCommand.php
+++ b/src/Registration/Application/UseCase/RegisterUser/RegisterUserCommand.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Registration\Application\UseCase\RegisterUser;
+
+final readonly class RegisterUserCommand
+{
+    public function __construct(
+        public string $email,
+        public string $password,
+        public string $name,
+        public ?string $bio = null,
+    ) {}
+}

--- a/src/Registration/Application/UseCase/RegisterUser/RegisterUserCommandHandler.php
+++ b/src/Registration/Application/UseCase/RegisterUser/RegisterUserCommandHandler.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Registration\Application\UseCase\RegisterUser;
+
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+use Throwable;
+use Twitter\IAM\Domain\User\Exception\UserAlreadyExistsException;
+use Twitter\IAM\Domain\User\Model\Email;
+use Twitter\IAM\Domain\User\Model\PasswordHash;
+use Twitter\IAM\Domain\User\Model\User;
+use Twitter\Profile\Domain\Profile\Exception\UserNotFoundException;
+use Twitter\Profile\Domain\Profile\Model\Profile;
+
+final readonly class RegisterUserCommandHandler
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {}
+
+    public function handle(RegisterUserCommand $command): RegisterUserCommandResult
+    {
+        $email = Email::fromString($command->email);
+        $passwordHash = PasswordHash::fromPlainPassword($command->password);
+
+        try {
+            $user = User::create($email, $passwordHash);
+            $userId = $user->id();
+            $profile = Profile::create(
+                userId: $user->id(),
+                name: $command->name,
+                bio: $command->bio,
+            );
+
+            $connection = $this->entityManager->getConnection();
+            $connection->beginTransaction();
+
+            try {
+                $this->entityManager->persist($user);
+                $this->entityManager->persist($profile);
+                $this->entityManager->flush();
+
+                $connection->commit();
+            } catch (Throwable $e) {
+                $connection->rollBack();
+                throw $e;
+            }
+
+            return new RegisterUserCommandResult($userId);
+        } catch (UniqueConstraintViolationException) {
+            throw new UserAlreadyExistsException((string) $email);
+        } catch (ForeignKeyConstraintViolationException) {
+            // Should be impossible for fresh registration, but keep consistent error mapping.
+            throw new UserNotFoundException($userId);
+        }
+    }
+}

--- a/src/Registration/Application/UseCase/RegisterUser/RegisterUserCommandResult.php
+++ b/src/Registration/Application/UseCase/RegisterUser/RegisterUserCommandResult.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Registration\Application\UseCase\RegisterUser;
+
+final readonly class RegisterUserCommandResult
+{
+    public function __construct(
+        public string $userId,
+    ) {}
+}

--- a/src/Registration/UI/REST/Controller/RegisterUserController.php
+++ b/src/Registration/UI/REST/Controller/RegisterUserController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Registration\UI\REST\Controller;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+use Symfony\Component\Routing\Attribute\Route;
+use Twitter\Registration\Application\UseCase\RegisterUser\RegisterUserCommand;
+use Twitter\Registration\Application\UseCase\RegisterUser\RegisterUserCommandHandler;
+
+#[Route('/api/registration', name: 'api_registration', methods: ['POST'])]
+final readonly class RegisterUserController
+{
+    public function __construct(
+        private RegisterUserCommandHandler $registerUserCommandHandler,
+    ) {}
+
+    public function __invoke(
+        #[MapRequestPayload]
+        RegisterUserRequest $request,
+    ): JsonResponse {
+        $result = $this->registerUserCommandHandler->handle(
+            new RegisterUserCommand(
+                email: $request->email(),
+                password: $request->password(),
+                name: $request->name(),
+                bio: $request->bio(),
+            ),
+        );
+
+        return new JsonResponse(['id' => $result->userId], Response::HTTP_CREATED);
+    }
+}

--- a/src/Registration/UI/REST/Controller/RegisterUserRequest.php
+++ b/src/Registration/UI/REST/Controller/RegisterUserRequest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Registration\UI\REST\Controller;
+
+use Assert\Assert;
+
+final readonly class RegisterUserRequest
+{
+    public function __construct(
+        private string $email,
+        private string $password,
+        private string $name,
+        private ?string $bio = null,
+    ) {
+        Assert::lazy()
+            ->tryAll()
+            ->that($this->email, 'email')
+            ->email()
+            ->that($this->password, 'password')
+            ->notBlank()
+            ->minLength(8)
+            ->regex('/[a-z]/', 'Password must contain at least one lowercase letter')
+            ->regex('/[A-Z]/', 'Password must contain at least one uppercase letter')
+            ->regex('/\d/', 'Password must contain at least one digit')
+            ->regex('/[^a-zA-Z0-9]/', 'Password must contain at least one special character')
+            ->that($this->name, 'name')
+            ->notBlank()
+            ->minLength(3)
+            ->maxLength(50)
+            ->that($this->bio, 'bio')
+            ->nullOr()
+            ->maxLength(300)
+            ->verifyNow();
+    }
+
+    public function email(): string
+    {
+        return $this->email;
+    }
+
+    public function password(): string
+    {
+        return $this->password;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function bio(): ?string
+    {
+        return $this->bio;
+    }
+}

--- a/templates/layout/base.html.twig
+++ b/templates/layout/base.html.twig
@@ -75,6 +75,7 @@
                 createUser: '{{ path('api_create_user') }}',
                 login: '{{ path('api_login_check') }}',
                 createProfile: '{{ path('api_create_profile') }}',
+                registerUser: '{{ path('api_registration') }}',
                 successRedirect: '{{ path('homepage') }}',
 
                 // New routes

--- a/tests/Registration/Application/UseCase/RegisterUser/RegisterUserCommandHandlerTest.php
+++ b/tests/Registration/Application/UseCase/RegisterUser/RegisterUserCommandHandlerTest.php
@@ -21,7 +21,7 @@ use Twitter\IAM\Domain\User\Exception\UserAlreadyExistsException;
 use Twitter\Registration\Application\UseCase\RegisterUser\RegisterUserCommand;
 use Twitter\Registration\Application\UseCase\RegisterUser\RegisterUserCommandHandler;
 
-#[Group('unit')]
+#[Group('component')]
 #[CoversClass(RegisterUserCommandHandler::class)]
 final class RegisterUserCommandHandlerTest extends TestCase
 {

--- a/tests/Registration/Application/UseCase/RegisterUser/RegisterUserCommandHandlerTest.php
+++ b/tests/Registration/Application/UseCase/RegisterUser/RegisterUserCommandHandlerTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Tests\Registration\Application\UseCase\RegisterUser;
+
+use Assert\LazyAssertionException;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Twitter\IAM\Domain\User\Exception\InvalidEmailException;
+use Twitter\IAM\Domain\User\Exception\InvalidPasswordException;
+use Twitter\IAM\Domain\User\Exception\UserAlreadyExistsException;
+use Twitter\Registration\Application\UseCase\RegisterUser\RegisterUserCommand;
+use Twitter\Registration\Application\UseCase\RegisterUser\RegisterUserCommandHandler;
+
+#[Group('unit')]
+#[CoversClass(RegisterUserCommandHandler::class)]
+final class RegisterUserCommandHandlerTest extends TestCase
+{
+    private RegisterUserCommandHandler $handler;
+    private EntityManagerInterface&MockObject $entityManager;
+    private Connection&MockObject $connection;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->connection = $this->createMock(Connection::class);
+
+        $this->handler = new RegisterUserCommandHandler(
+            $this->entityManager,
+        );
+    }
+
+    #[Test]
+    public function createsUserAndProfileInSingleTransaction(): void
+    {
+        $this->entityManager
+            ->expects(self::once())
+            ->method('getConnection')
+            ->willReturn($this->connection);
+
+        $this->connection
+            ->expects(self::once())
+            ->method('beginTransaction');
+
+        $this->connection
+            ->expects(self::once())
+            ->method('commit');
+
+        $this->connection
+            ->expects(self::never())
+            ->method('rollBack');
+
+        $this->entityManager
+            ->expects(self::exactly(2))
+            ->method('persist');
+
+        $this->entityManager
+            ->expects(self::once())
+            ->method('flush');
+
+        $result = $this->handler->handle(new RegisterUserCommand(
+            email: 'test@example.com',
+            password: 'Qwerty.123',
+            name: 'John Doe',
+            bio: 'Bio',
+        ));
+
+        self::assertNotEmpty($result->userId);
+        self::assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i',
+            $result->userId,
+        );
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function failsWhenEmailIsInvalid(): void
+    {
+        $this->expectException(InvalidEmailException::class);
+
+        $this->entityManager
+            ->expects(self::never())
+            ->method('getConnection');
+
+        $this->handler->handle(new RegisterUserCommand(
+            email: 'invalid',
+            password: 'Qwerty.123',
+            name: 'John Doe',
+            bio: null,
+        ));
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function failsWhenPasswordIsInvalid(): void
+    {
+        $this->expectException(InvalidPasswordException::class);
+
+        $this->entityManager
+            ->expects(self::never())
+            ->method('getConnection');
+
+        $this->handler->handle(new RegisterUserCommand(
+            email: 'test@example.com',
+            password: 'invalid',
+            name: 'John Doe',
+            bio: null,
+        ));
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function failsWhenProfileNameIsInvalid(): void
+    {
+        $this->expectException(LazyAssertionException::class);
+
+        $this->entityManager
+            ->expects(self::never())
+            ->method('getConnection');
+
+        $this->handler->handle(new RegisterUserCommand(
+            email: 'test@example.com',
+            password: 'Qwerty.123',
+            name: 'ab',
+            bio: null,
+        ));
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function rollsBackWhenUserAlreadyExists(): void
+    {
+        $this->expectException(UserAlreadyExistsException::class);
+
+        $this->entityManager
+            ->expects(self::once())
+            ->method('getConnection')
+            ->willReturn($this->connection);
+
+        $this->connection
+            ->expects(self::once())
+            ->method('beginTransaction');
+
+        $this->connection
+            ->expects(self::once())
+            ->method('rollBack');
+
+        $this->connection
+            ->expects(self::never())
+            ->method('commit');
+
+        $this->entityManager
+            ->expects(self::exactly(2))
+            ->method('persist');
+
+        $this->entityManager
+            ->expects(self::once())
+            ->method('flush')
+            ->willThrowException($this->createMock(UniqueConstraintViolationException::class));
+
+        $this->handler->handle(new RegisterUserCommand(
+            email: 'test@example.com',
+            password: 'Qwerty.123',
+            name: 'John Doe',
+            bio: null,
+        ));
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function propagatesUnexpectedFailuresAndRollsBack(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->entityManager
+            ->expects(self::once())
+            ->method('getConnection')
+            ->willReturn($this->connection);
+
+        $this->connection
+            ->expects(self::once())
+            ->method('beginTransaction');
+
+        $this->connection
+            ->expects(self::once())
+            ->method('rollBack');
+
+        $this->connection
+            ->expects(self::never())
+            ->method('commit');
+
+        $this->entityManager
+            ->expects(self::exactly(2))
+            ->method('persist');
+
+        $this->entityManager
+            ->expects(self::once())
+            ->method('flush')
+            ->willThrowException(new RuntimeException());
+
+        $this->handler->handle(new RegisterUserCommand(
+            email: 'test@example.com',
+            password: 'Qwerty.123',
+            name: 'John Doe',
+            bio: null,
+        ));
+    }
+}


### PR DESCRIPTION
**Jira**: [SCRUM-84](https://epam-team-php.atlassian.net/browse/SCRUM-84)

## Description

Implement a single transaction registration command.

## How to roll back?

Revert this pull request.

## How has this been tested?

Covered by component tests.

```
PHPUnit 12.5.7 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.17
Configuration: /app/phpunit.dist.xml

......                                                              6 / 6 (100%)

Time: 00:00.730, Memory: 18.00 MB

Register User Command Handler (Twitter\Tests\Registration\Application\UseCase\RegisterUser\RegisterUserCommandHandler)
 Γ£ö Creates user and profile in single transaction
 Γ£ö Fails when email is invalid
 Γ£ö Fails when password is invalid
 Γ£ö Fails when profile name is invalid
 Γ£ö Rolls back when user already exists
 Γ£ö Propagates unexpected failures and rolls back

OK (6 tests, 16 assertions)
```

## Media attachments

<img width="1920" height="1032" alt="Screenshot 2026-01-27 125259" src="https://github.com/user-attachments/assets/9c644bad-ebe0-4524-a894-0b2d33406b07" />
<img width="1920" height="1032" alt="Screenshot 2026-01-27 125146" src="https://github.com/user-attachments/assets/c2cee20a-0aca-4bc4-ac2b-771eef92a591" />
<img width="1920" height="1032" alt="Screenshot 2026-01-27 125210" src="https://github.com/user-attachments/assets/671ed7b2-c23a-4a7f-a56f-39c22ce9a345" />
<img width="1920" height="1032" alt="Screenshot 2026-01-27 125206" src="https://github.com/user-attachments/assets/34a5053e-f237-4d05-9d10-79e67acbc09f" />
<img width="1920" height="1032" alt="Screenshot 2026-01-27 125201" src="https://github.com/user-attachments/assets/629987a1-0e8d-48b6-83c0-429eb436ff95" />
