### PR TITLE
fix(like): SCRUM-100 Allow Unauthorized Users to Listen Like Events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
         "phpstan/phpstan": "^2.1.37",
         "phpstan/phpstan-doctrine": "^2.0.14",
         "phpstan/phpstan-symfony": "^2.0.12",
-        "phpunit/phpunit": "^12.5.7",
+        "phpunit/phpunit": "^12.5.8",
         "symfony/browser-kit": "7.4.*",
         "symfony/css-selector": "7.4.*"
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "217cb5a0bf13e41ccd6821d788d6299f",
+    "content-hash": "28d1cdb5dce805bd73ecb2364922a91c",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -7749,16 +7749,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.7",
+            "version": "12.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "79dee3d2685b80518e94b9ea741b3f822b213a5e"
+                "reference": "37ddb96c14bfee10304825edbb7e66d341ec6889"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/79dee3d2685b80518e94b9ea741b3f822b213a5e",
-                "reference": "79dee3d2685b80518e94b9ea741b3f822b213a5e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/37ddb96c14bfee10304825edbb7e66d341ec6889",
+                "reference": "37ddb96c14bfee10304825edbb7e66d341ec6889",
                 "shasum": ""
             },
             "require": {
@@ -7826,7 +7826,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.7"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.8"
             },
             "funding": [
                 {
@@ -7850,7 +7850,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-24T16:12:53+00:00"
+            "time": "2026-01-27T06:12:29+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/public/js/realtime.js
+++ b/public/js/realtime.js
@@ -44,9 +44,6 @@
     const selector = `.tweet-like-btn[data-tweet-id="${tweetId}"] .tweet-like-count`;
 
     document.querySelectorAll(selector).forEach((el) => {
-      const btn = el.closest('.tweet-like-btn');
-      if (btn?.disabled) return;
-
       if (el.textContent !== String(count)) {
         el.textContent = count;
       }


### PR DESCRIPTION
**Jira**: [SCRUM-100](https://epam-team-php.atlassian.net/browse/SCRUM-100)

## Description

Fix real-time like count updates for guests by removing the disabled-button guard in the Mercure SSE handler, so unauthenticated users stay in sync with like counters.

## How to roll back?

Revert this pull request.

## How has this been tested?

Manually tested.

## Media attachments

https://github.com/user-attachments/assets/77cbfc2f-5ed1-4bb2-9b76-f68a2ddeb948

