### PR TITLE
Grafana dashboard

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -97,6 +97,7 @@ services:
       - "9090:9090"
     volumes:
       - ./infra/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./infra/prometheus/alerts.yml:/etc/prometheus/alerts.yml:ro
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
 
@@ -110,6 +111,8 @@ services:
       GF_SECURITY_ADMIN_PASSWORD: admin
     volumes:
       - grafana_data:/var/lib/grafana
+      - ./infra/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./infra/grafana/dashboards:/var/lib/grafana/dashboards:ro
     depends_on:
       - prometheus
 

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "jimdo/prometheus_client_php": "^0.9.1",
         "lexik/jwt-authentication-bundle": "^3.2",
         "phpstan/phpdoc-parser": "^2.3.2",
+        "promphp/prometheus_client_php": "^0.9.1",
         "runtime/frankenphp-symfony": "^0.2.0",
         "symfony/asset": "7.4.*",
         "symfony/console": "7.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec459dee89c48b0a5e037ed882eda10e",
+    "content-hash": "5ec143874986067e3aa73e6f2ab9fe0e",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1948,6 +1948,57 @@
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
             },
             "time": "2026-01-25T14:56:51+00:00"
+        },
+        {
+            "name": "promphp/prometheus_client_php",
+            "version": "v0.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PromPHP/prometheus_client_php.git",
+                "reference": "cf3ea93197400a97464ff9bee78cf2169f035327"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PromPHP/prometheus_client_php/zipball/cf3ea93197400a97464ff9bee78cf2169f035327",
+                "reference": "cf3ea93197400a97464ff9bee78cf2169f035327",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.2",
+                "php": ">=5.6.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.1.0"
+            },
+            "suggest": {
+                "ext-apc": "Required if using APCu.",
+                "ext-redis": "Required if using Redis."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Prometheus\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Joscha",
+                    "email": "joscha@schnipseljagd.org"
+                },
+                {
+                    "name": "Jan Brauer",
+                    "email": "jan.brauer@jimdo.com"
+                }
+            ],
+            "support": {
+                "issues": "https://github.com/PromPHP/prometheus_client_php/issues",
+                "source": "https://github.com/PromPHP/prometheus_client_php/tree/v0.9.1"
+            },
+            "time": "2017-11-06T11:00:07+00:00"
         },
         {
             "name": "psr/cache",

--- a/docs/k6-loadtest.md
+++ b/docs/k6-loadtest.md
@@ -1,0 +1,120 @@
+# k6 Load Test — Twitter
+
+This document explains how to prepare test data for k6, run the stress test, and fully remove all loadtest-related data afterwards.
+
+Assumptions:
+- MySQL runs in Docker Compose as service `database`
+- Database: `app`
+- MySQL credentials: `app / !ChangeMe!`
+- k6 script: `loadtest-twitter.js`
+- JWT `token_ttl: 900` seconds (15 minutes)
+
+---
+
+## 1) Make sure the stack is running
+
+```bash
+docker compose up -d
+docker compose ps
+```
+
+## 2) Create loadtest users
+Email pattern: loadtest_000001@local.test … loadtest_002000@local.test
+Password: Pa$$word1
+
+```bash
+HASH='$2y$12$d765Nx30xRCm/cttxY4kJ.OmA3k4Ptd.4wz48.9WNaAbLBUAGK5aa'
+for i in $(seq -w 1 2000); do
+  echo "INSERT INTO users (id, roles, email, password_hash, created_at, updated_at)
+        VALUES (UUID_TO_BIN(UUID()), '[\"ROLE_USER\"]', 'loadtest_${i}@local.test', '${HASH}', NOW(), NOW());"
+done | docker compose exec -T database mysql -uapp -p'!ChangeMe!' app
+```
+
+Verify:
+
+```bash
+docker compose exec -T database mysql -uapp -p'!ChangeMe!' -e \
+"SELECT COUNT(*) AS cnt FROM app.users WHERE email LIKE 'loadtest_%';"
+```
+
+
+## 3) Create profiles for loadtest users
+profiles.user_id has FK ON DELETE CASCADE to users.id, so profiles are removed automatically when users are deleted.
+Create profiles for all loadtest users that do not have a profile yet:
+
+```bash
+docker compose exec -T database mysql -uapp -p'!ChangeMe!' app -e "
+INSERT INTO profiles (user_id, name, bio, created_at, updated_at)
+SELECT u.id,
+       CONCAT('LoadUser ', SUBSTRING_INDEX(SUBSTRING_INDEX(u.email, '@', 1), '_', -1)),
+       'LOADTEST',
+       NOW(),
+       NOW()
+FROM users u
+LEFT JOIN profiles p ON p.user_id = u.id
+WHERE u.email LIKE 'loadtest_%'
+  AND p.user_id IS NULL;
+"
+```
+
+Verify:
+
+```bash
+docker compose exec -T database mysql -uapp -p'!ChangeMe!' -e "
+SELECT
+  (SELECT COUNT(*) FROM app.users WHERE email LIKE 'loadtest_%') AS users_cnt,
+  (SELECT COUNT(*) FROM app.profiles WHERE user_id IN (SELECT id FROM app.users WHERE email LIKE 'loadtest_%')) AS profiles_cnt;
+"
+```
+
+## 4) Run the k6 test
+```bash
+k6 run loadtest-twitter.js
+```
+
+## 5) Cleanup — delete loadtest users and related data
+Schema facts:
+profiles.user_id has ON DELETE CASCADE → profiles are removed automatically
+tweets.user_id has ON DELETE CASCADE → tweets are removed automatically
+likes has no foreign keys → likes must be deleted manually
+Correct cleanup flow:
+delete likes:
+likes made by loadtest users
+likes on tweets that belong to loadtest users (if other users liked them)
+delete loadtest users (profiles + tweets are removed via cascades)
+
+```bash
+docker compose exec -T database mysql -uapp -p'!ChangeMe!' app -e "
+-- Likes made by loadtest users
+DELETE FROM likes
+WHERE user_id IN (SELECT id FROM users WHERE email LIKE 'loadtest_%');
+
+-- Likes on tweets of loadtest users (if other users liked them)
+DELETE FROM likes
+WHERE tweet_id IN (
+  SELECT t.id
+  FROM tweets t
+  JOIN users u ON u.id = t.user_id
+  WHERE u.email LIKE 'loadtest_%'
+);
+
+-- Delete users (profiles + tweets are deleted via ON DELETE CASCADE)
+DELETE FROM users
+WHERE email LIKE 'loadtest_%';
+"
+```
+
+Verify:
+
+```bash
+docker compose exec -T database mysql -uapp -p'!ChangeMe!' -e \
+"SELECT COUNT(*) AS cnt FROM app.users WHERE email LIKE 'loadtest_%';"
+```
+
+## 6) Common issues
+
+### `Field 'updated_at' doesn't have a default value`
+Cause: `updated_at` is `NOT NULL` in `users` and `profiles`, and MySQL has no default value for it.  
+Fix: Always set `updated_at` explicitly in INSERTs (the commands above use `NOW()`).
+
+---

--- a/infra/grafana/dashboards/twitter-web.json
+++ b/infra/grafana/dashboards/twitter-web.json
@@ -1,0 +1,426 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "panels": [],
+      "title": "Traffic",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          },
+          "unit": "percent",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 8, "x": 0, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.3.3",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "100 * sum(rate(http_requests_total{status=~\"5..\",route!~\"^(metrics|api_health_check)$\"}[1m])) / clamp_min(sum(rate(http_requests_total{route!~\"^(metrics|api_health_check)$\"}[1m])), 1)",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "5xx error rate (%)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          },
+          "unit": "percent",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 8, "x": 8, "y": 1 },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.3.3",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "100 * sum(rate(http_requests_total{status=~\"4..\",route!~\"^(metrics|api_health_check)$\"}[1m])) / clamp_min(sum(rate(http_requests_total{route!~\"^(metrics|api_health_check)$\"}[1m])), 1)",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "4xx error rate (%)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 8, "x": 16, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.3.3",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "sum(rate(http_rate_limited_total{route!~\"^(metrics|api_health_check)$\"}[1m])) * 60",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "429 rate-limited (per min)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 80 }]
+          },
+          "unit": "req/s",
+          "unitScale": false
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "sum by (route) (rate(http_requests_total{route!~\"^(metrics|api_health_check)$\"}[30s]))",
+          "legendFormat": "{{route}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RPS by route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }]
+          },
+          "unit": "s",
+          "unitScale": false
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "id": 4,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket{route!~\"^(metrics|api_health_check)$\"}[1m])))",
+          "legendFormat": "{{route}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Latency p95 by route (seconds)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }]
+          },
+          "unit": "ms",
+          "unitScale": false
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "id": 9,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "1000 * sum by (route) (rate(http_request_duration_seconds_sum{route!~\"^(metrics|api_health_check)$\"}[1m])) / clamp_min(sum by (route) (rate(http_request_duration_seconds_count{route!~\"^(metrics|api_health_check)$\"}[1m])), 1e-9)",
+          "legendFormat": "{{route}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Avg latency by route (ms)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1.5 }]
+          },
+          "unit": "s",
+          "unitScale": false
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "id": 7,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, route) (rate(http_request_duration_seconds_bucket{route!~\"^(metrics|api_health_check)$\"}[1m])))",
+          "legendFormat": "{{route}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Latency p99 by route (seconds)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 80 }]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 20 },
+      "id": 5,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true,
+        "sortBy": [{ "desc": false, "displayName": "status" }]
+      },
+      "pluginVersion": "10.3.3",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "sum by (route, status) (increase(http_requests_total{route!~\"^(metrics|api_health_check)$\"}[1m]))",
+          "format": "table",
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests by status (route/status) — last 1m",
+      "type": "table"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": ["twitter", "web", "api"],
+  "templating": { "list": [] },
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Twitter – Web/API",
+  "uid": "twitter-web",
+  "version": 5,
+  "weekStart": ""
+}

--- a/infra/grafana/provisioning/dashboards/dashboards.yml
+++ b/infra/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+    - name: "Twitter"
+      orgId: 1
+      folder: "Twitter"
+      type: file
+      disableDeletion: true
+      editable: true
+      options:
+          path: /var/lib/grafana/dashboards

--- a/infra/grafana/provisioning/datasources/datasource.yml
+++ b/infra/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+    - name: Prometheus
+      type: prometheus
+      access: proxy
+      uid: prometheus
+      url: http://prometheus:9090
+      isDefault: true

--- a/infra/prometheus/alerts.yml
+++ b/infra/prometheus/alerts.yml
@@ -1,0 +1,26 @@
+groups:
+    - name: twitter-observability
+      rules:
+          - alert: HighErrorRate5xx
+            expr: (sum(rate(http_requests_total{status=~"5.."}[5m])) / sum(rate(http_requests_total[5m]))) > 0.02
+            for: 5m
+            labels:
+                severity: warning
+            annotations:
+                summary: "High 5xx error rate (>2% for 5m)"
+
+          - alert: RabbitMQQueueTooLong
+            expr: max(rabbitmq_queue_messages_ready{queue!~"(?i).*dlq.*|(?i).*dead.*|(?i).*failure.*"}) > 100
+            for: 10m
+            labels:
+                severity: warning
+            annotations:
+                summary: "RabbitMQ queue backlog too large (ready > 100 for 10m)"
+
+          - alert: RabbitMQDLQNotEmpty
+            expr: sum(rabbitmq_queue_messages_ready{queue=~"(?i).*dlq.*|(?i).*dead.*|(?i).*failure.*"}) > 0
+            for: 5m
+            labels:
+                severity: warning
+            annotations:
+                summary: "DLQ has messages (ready > 0)"

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -1,5 +1,8 @@
 global:
     scrape_interval: 5s
+    
+rule_files:
+    - /etc/prometheus/alerts.yml
 
 scrape_configs:
     - job_name: symfony

--- a/loadtest-twitter.js
+++ b/loadtest-twitter.js
@@ -1,0 +1,367 @@
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
+import sql from 'k6/x/sql';
+import driver from 'k6/x/sql/driver/mysql';
+
+/* =========================
+   🔧 CONFIG
+========================= */
+
+const MySQL_USER = 'app';
+const MySQL_PASSWORD = '!ChangeMe!';
+const MySQL_IP = '127.0.0.1';
+const MySQL_PORT = '3306';
+const MySQL_DATABASE = 'app';
+
+const db = sql.open(
+  driver,
+  `${MySQL_USER}:${MySQL_PASSWORD}@tcp(${MySQL_IP}:${MySQL_PORT})/${MySQL_DATABASE}`
+);
+
+const BASE_URL = 'https://localhost';
+
+const FEED_LIMIT = 50;
+const maxFeedPages = 7;
+const scrollProbability = 0.9;
+
+const THINK_TIME_MIN = 0;
+const THINK_TIME_MAX = 0;
+
+const JWT_TTL_SECONDS = 900;
+const JWT_REFRESH_SAFETY_SECONDS = 60;
+
+/* =========================
+   📊 OPTIONS
+========================= */
+
+const endpoints = [
+  'tweets_page1',
+  'tweets_page2',
+  'tweets_page3',
+  'tweets_page4plus',
+  'ProfileNameBio',
+  'ProfileFeed',
+  'Like',
+  'Login',
+];
+
+export const options = {
+  insecureSkipTLSVerify: true,
+
+  scenarios: {
+    auth_stress: {
+      executor: 'ramping-vus',
+      exec: 'scenarioAuth',
+      stages: [
+        { duration: '10s', target: 3 },
+        { duration: '3m', target: 3 },
+        { duration: '3m', target: 3 },
+        { duration: '1m', target: 3 },
+      ],
+      gracefulRampDown: '30s',
+      gracefulStop: '30s',
+    },
+
+    feed_stress: {
+      executor: 'ramping-vus',
+      exec: 'scenarioFeed',
+      stages: [
+        { duration: '10s', target: 6 },
+        { duration: '3m', target: 6 },
+        { duration: '3m', target: 6 },
+        { duration: '1m', target: 6 },
+      ],
+      gracefulRampDown: '30s',
+      gracefulStop: '30s',
+    },
+
+    profile_stress: {
+      executor: 'ramping-vus',
+      exec: 'scenarioProfile',
+      stages: [
+        { duration: '10s', target: 3 },
+        { duration: '3m', target: 3 },
+        { duration: '3m', target: 3 },
+        { duration: '1m', target: 3 },
+      ],
+      gracefulRampDown: '30s',
+      gracefulStop: '30s',
+    },
+
+    like_stress: {
+      executor: 'ramping-vus',
+      exec: 'scenarioLike',
+      stages: [
+        { duration: '10s', target: 2 },
+        { duration: '3m', target: 2 },
+        { duration: '3m', target: 2 },
+        { duration: '1m', target: 2 },
+      ],
+      gracefulRampDown: '30s',
+      gracefulStop: '30s',
+    },
+  },
+
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_waiting: ['p(95)<10000'],
+    ...endpoints.reduce(
+      (acc, endpoint) => ({
+        ...acc,
+        [`http_req_duration{endpoint:${endpoint}}`]: ['p(95)<10000'],
+        [`http_reqs{endpoint:${endpoint}}`]: ['count>=0'],
+      }),
+      {}
+    ),
+  },
+};
+
+/* =========================
+   📦 DATA LOAD
+========================= */
+
+function asciiRowToString(v) {
+  return String.fromCharCode(...v);
+}
+
+function mustNotBeEmpty(arr, name) {
+  if (!arr || arr.length === 0) {
+    throw new Error(`[TEST DATA] ${name} is empty`);
+  }
+}
+
+let rows;
+
+let emailsAvailable = [];
+rows = db.query("SELECT email FROM app.users WHERE email LIKE 'loadtest_%' LIMIT 10000;");
+for (const row of rows) emailsAvailable.push(asciiRowToString(row.email));
+
+let profilesAvailable = [];
+rows = db.query(`
+  SELECT BIN_TO_UUID(user_id) AS profile_uuid
+  FROM app.profiles
+  WHERE user_id IN (SELECT id FROM app.users WHERE email LIKE 'loadtest_%')
+    LIMIT 10000;
+`);
+for (const row of rows) profilesAvailable.push(asciiRowToString(row.profile_uuid));
+
+let tweetsAvailable = [];
+rows = db.query('SELECT BIN_TO_UUID(id) as tweet_id FROM app.tweets LIMIT 10000;');
+for (const row of rows) tweetsAvailable.push(asciiRowToString(row.tweet_id));
+
+mustNotBeEmpty(emailsAvailable, 'emailsAvailable (loadtest users)');
+mustNotBeEmpty(profilesAvailable, 'profilesAvailable (loadtest profiles)');
+mustNotBeEmpty(tweetsAvailable, 'tweetsAvailable (tweets)');
+
+if (__VU === 1) {
+  console.log(
+    `#TEST DATA# Loadtest Emails: ${emailsAvailable.length} | Loadtest Profiles: ${profilesAvailable.length} | TweetsToLike: ${tweetsAvailable.length}`
+  );
+}
+
+export function teardown() {
+  db.close();
+}
+
+/* =========================
+   🛠 HELPERS
+========================= */
+
+function randomItem(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function randomSleep() {
+  const t = THINK_TIME_MIN + Math.random() * (THINK_TIME_MAX - THINK_TIME_MIN);
+  sleep(t);
+}
+
+function authHeaders(jwt) {
+  return jwt ? { headers: { Authorization: `Bearer ${jwt}` } } : {};
+}
+
+function nowSeconds() {
+  return Math.floor(Date.now() / 1000);
+}
+
+/* =========================
+   🔐 AUTH
+========================= */
+
+function login() {
+  const payload = JSON.stringify({
+    email: randomItem(emailsAvailable),
+    password: 'Pa$$word1',
+  });
+
+  const params = {
+    headers: { 'Content-Type': 'application/json' },
+    tags: {
+      endpoint: 'Login',
+      name: 'POST /api/token',
+    },
+  };
+
+  return group('POST /api/token (login)', () => {
+    const res = http.post(`${BASE_URL}/api/token`, payload, params);
+    const token = res.status === 200 ? res.json('token') : null;
+
+    check(res, {
+      'login status is 200': (r) => r.status === 200,
+      'JWT received': () => !!token,
+    });
+
+    return token;
+  });
+}
+
+/* =========================
+   🔑 JWT CACHE (per VU)
+========================= */
+
+let jwtCache = null;
+let jwtCacheCreatedAt = 0;
+
+function jwtExpiredOrSoon() {
+  if (!jwtCache) return true;
+  const age = nowSeconds() - jwtCacheCreatedAt;
+  return age >= JWT_TTL_SECONDS - JWT_REFRESH_SAFETY_SECONDS;
+}
+
+function getJwtOncePerVu() {
+  if (!jwtCache || jwtExpiredOrSoon()) {
+    jwtCache = login();
+    jwtCacheCreatedAt = nowSeconds();
+  }
+  return jwtCache;
+}
+
+/* =========================
+   📰 FEED
+========================= */
+
+function mainFeed(jwt) {
+  let page = 1;
+
+  while (page <= maxFeedPages) {
+    const endpointTag =
+      page === 1
+        ? 'tweets_page1'
+        : page === 2
+          ? 'tweets_page2'
+          : page === 3
+            ? 'tweets_page3'
+            : 'tweets_page4plus';
+
+    group(`GET /api/tweets (page=${page})`, () => {
+      http.get(`${BASE_URL}/api/tweets?limit=${FEED_LIMIT}&page=${page}`, {
+        ...authHeaders(jwt),
+        tags: {
+          endpoint: endpointTag,
+          name: 'GET /api/tweets',
+        },
+      });
+    });
+
+    if (page === maxFeedPages || Math.random() > scrollProbability) break;
+    page++;
+    randomSleep();
+  }
+}
+
+/* =========================
+   👤 PROFILE
+========================= */
+
+function getProfile(jwt) {
+  const profileId = randomItem(profilesAvailable);
+
+  group('GET /api/profiles/{id}', () => {
+    const res = http.get(`${BASE_URL}/api/profiles/${profileId}`, {
+      ...authHeaders(jwt),
+      tags: {
+        endpoint: 'ProfileNameBio',
+        name: 'GET /api/profiles/:id',
+      },
+    });
+
+    if (res.status === 401) jwtCache = null;
+  });
+
+  group('GET /api/profiles/{id}/tweets', () => {
+    const res = http.get(`${BASE_URL}/api/profiles/${profileId}/tweets?limit=${FEED_LIMIT}&page=1`, {
+      ...authHeaders(jwt),
+      tags: {
+        endpoint: 'ProfileFeed',
+        name: 'GET /api/profiles/:id/tweets',
+      },
+    });
+
+    if (res.status === 401) jwtCache = null;
+  });
+}
+
+/* =========================
+   ❤️ LIKE
+========================= */
+
+function toggleLike(jwt) {
+  const tweetId = randomItem(tweetsAvailable);
+
+  group('POST /api/tweets/{id}/likes/toggle', () => {
+    const res = http.post(`${BASE_URL}/api/tweets/${tweetId}/likes/toggle`, null, {
+      ...authHeaders(jwt),
+      tags: {
+        endpoint: 'Like',
+        name: 'POST /api/tweets/:id/likes/toggle',
+      },
+    });
+
+    if (res.status === 401) jwtCache = null;
+  });
+}
+
+/* =========================
+   🚶 SCENARIOS
+========================= */
+
+export function scenarioAuth() {
+  login();
+  randomSleep();
+}
+
+export function scenarioFeed() {
+  mainFeed(null);
+  const jwt = getJwtOncePerVu();
+  mainFeed(jwt);
+  randomSleep();
+}
+
+export function scenarioProfile() {
+  const jwt = getJwtOncePerVu();
+  const views = 3 + Math.floor(Math.random() * 6);
+  for (let i = 0; i < views; i++) {
+    getProfile(jwt);
+    randomSleep();
+  }
+}
+
+export function scenarioLike() {
+  const jwt = getJwtOncePerVu();
+  const likes = 5 + Math.floor(Math.random() * 8);
+  for (let i = 0; i < likes; i++) {
+    toggleLike(jwt);
+    randomSleep();
+  }
+}
+
+/* =========================
+   SUMMARY
+========================= */
+
+export function handleSummary(data) {
+  return {
+    stdout: textSummary(data, { indent: ' ', enableColors: true }),
+  };
+}

--- a/src/Metrics/EventSubscriber/HttpMetricsSubscriber.php
+++ b/src/Metrics/EventSubscriber/HttpMetricsSubscriber.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Twitter\Metrics\EventSubscriber;
 
 use Prometheus\CollectorRegistry;
+use Prometheus\Counter;
+use Prometheus\Histogram;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
@@ -12,11 +14,45 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 final class HttpMetricsSubscriber implements EventSubscriberInterface
 {
-    private float $start;
+    private const START_ATTR = '_metrics_start_time';
+
+    private Counter $requestsTotal;
+    private Histogram $latency;
+    private Counter $errorsTotal;
+    private Counter $rateLimitedTotal;
 
     public function __construct(
         private readonly CollectorRegistry $registry,
-    ) {}
+    ) {
+        $this->requestsTotal = $this->registry->getOrRegisterCounter(
+            'http',
+            'requests_total',
+            'Total HTTP requests',
+            ['route', 'method', 'status']
+        );
+
+        $this->latency = $this->registry->getOrRegisterHistogram(
+            'http',
+            'request_duration_seconds',
+            'HTTP request latency',
+            ['route'],
+            [0.03, 0.05, 0.075, 0.1, 0.15, 0.2, 0.3, 0.4, 0.5, 0.75, 1, 2, 3, 5]
+        );
+
+        $this->errorsTotal = $this->registry->getOrRegisterCounter(
+            'http',
+            'requests_errors_total',
+            'HTTP 5xx errors',
+            ['route']
+        );
+
+        $this->rateLimitedTotal = $this->registry->getOrRegisterCounter(
+            'http',
+            'rate_limited_total',
+            'HTTP 429 (rate-limited) responses',
+            ['route', 'method']
+        );
+    }
 
     public static function getSubscribedEvents(): array
     {
@@ -32,7 +68,15 @@ final class HttpMetricsSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $this->start = microtime(true);
+        $request = $event->getRequest();
+
+        $route = (string) $request->attributes->get('_route', 'unknown');
+        if ('metrics' === $route) {
+            return;
+        }
+
+        // Safe per-request storage (no races)
+        $request->attributes->set(self::START_ATTR, microtime(true));
     }
 
     public function onResponse(ResponseEvent $event): void
@@ -41,46 +85,38 @@ final class HttpMetricsSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $duration = microtime(true) - $this->start;
-
         $request = $event->getRequest();
         $response = $event->getResponse();
 
-        $route = $request->attributes->get('_route', 'unknown');
-        $method = $request->getMethod();
-        $status = (string) $response->getStatusCode();
+        $route = (string) $request->attributes->get('_route', 'unknown');
+        if ('metrics' === $route) {
+            return;
+        }
+
+        $method = (string) $request->getMethod();
+        $statusCode = (int) $response->getStatusCode();
+        $status = (string) $statusCode;
+
+        $start = $request->attributes->get(self::START_ATTR);
+        $duration = is_float($start) ? (microtime(true) - $start) : 0.0;
+        if ($duration < 0) {
+            $duration = 0.0;
+        }
 
         // total requests
-        $requests = $this->registry->getOrRegisterCounter(
-            'http',
-            'requests_total',
-            'Total HTTP requests',
-            ['route', 'method', 'status']
-        );
-
-        $requests->inc([$route, $method, $status]);
+        $this->requestsTotal->inc([$route, $method, $status]);
 
         // latency histogram
-        $latency = $this->registry->getOrRegisterHistogram(
-            'http',
-            'request_duration_seconds',
-            'HTTP request latency',
-            ['route'],
-            [0.03, 0.05, 0.075, 0.1, 0.15, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 2, 3, 4, 5]
-        );
-
-        $latency->observe($duration, [$route]);
+        $this->latency->observe($duration, [$route]);
 
         // error counter
-        if ($response->getStatusCode() >= 500) {
-            $errors = $this->registry->getOrRegisterCounter(
-                'http',
-                'requests_errors_total',
-                'HTTP 5xx errors',
-                ['route']
-            );
+        if ($statusCode >= 500) {
+            $this->errorsTotal->inc([$route]);
+        }
 
-            $errors->inc([$route]);
+        // rate-limit counter
+        if (429 === $statusCode) {
+            $this->rateLimitedTotal->inc([$route, $method]);
         }
     }
 }


### PR DESCRIPTION
### Description
Implements observability and load testing for the Twitter app:
Adds HTTP metrics collection (RPS, status codes, latency) via HttpMetricsSubscriber.
Sets up Prometheus configuration and alert rules.
Adds Grafana provisioning and the “Twitter – Web/API” dashboard JSON.
Introduces a k6 stress test (loadtest-twitter.js) with multi-scenario workload, per-VU JWT caching (token_ttl=900s), and low-cardinality tags to avoid high time-series usage.
Adds documentation with steps to create/delete loadtest_* users and profiles to run k6 consistently.

### How to roll back?

Revert this pull request.

### Media attachments

<img width="1728" height="891" alt="image" src="https://github.com/user-attachments/assets/1c968edf-1279-45de-8802-287e1f0ebb16" />
