### PR TITLE
fix(tweet): #82 Fix `GetTweetsCommandHandler`

### DIFF
--- a/config/reference.php
+++ b/config/reference.php
@@ -1514,8 +1514,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type MercureConfig = array{
  *     hubs?: array<string, array{ // Default: []
- *         url?: scalar|Param|null, // URL of the hub's publish endpoint
- *         public_url?: scalar|Param|null, // URL of the hub's public endpoint // Default: null
+ *         url?: scalar|Param|null, // URL of the hub's publish endpoint // Default: null
+ *         public_url?: scalar|Param|null, // URL of the hub's public endpoint
  *         jwt?: string|array{ // JSON Web Token configuration.
  *             value?: scalar|Param|null, // JSON Web Token to use to publish to this hub.
  *             provider?: scalar|Param|null, // The ID of a service to call to provide the JSON Web Token.

--- a/src/Tweet/Application/UseCase/GetTweets/GetTweetsCommandHandler.php
+++ b/src/Tweet/Application/UseCase/GetTweets/GetTweetsCommandHandler.php
@@ -4,17 +4,21 @@ declare(strict_types=1);
 
 namespace Twitter\Tweet\Application\UseCase\GetTweets;
 
+use Override;
 use Twitter\Profile\Domain\Profile\Model\ProfileRepository;
 use Twitter\Tweet\Application\UseCase\Shared\TweetResponse;
 use Twitter\Tweet\Domain\Tweet\Model\TweetRepository;
 
-final readonly class GetTweetsCommandHandler
+final readonly class GetTweetsCommandHandler implements GetTweetsCommandHandlerInterface
 {
+    public const string UNKNOWN_AUTHOR = 'Unknown';
+
     public function __construct(
         private TweetRepository $tweetRepository,
         private ProfileRepository $profileRepository,
     ) {}
 
+    #[Override]
     public function handle(GetTweetsCommand $command): GetTweetsResponse
     {
         $tweets = $this->tweetRepository->getAllTweets($command->limit, $command->page);
@@ -41,7 +45,7 @@ final readonly class GetTweetsCommandHandler
                 createdAt: $tweet->createdAt(),
                 updatedAt: $tweet->updatedAt(),
                 authorId: $authorId,
-                authorName: $authorNameById[$authorId],
+                authorName: $authorNameById[$authorId] ?? self::UNKNOWN_AUTHOR,
                 likesCount: $tweet->likes(),
             );
         }

--- a/tests/Tweet/Application/UseCase/GetTweets/GetTweetsCommandHandlerTest.php
+++ b/tests/Tweet/Application/UseCase/GetTweets/GetTweetsCommandHandlerTest.php
@@ -128,4 +128,30 @@ final class GetTweetsCommandHandlerTest extends TestCase
         self::assertSame('Same Author', $result->tweets[0]->authorName);
         self::assertSame('Same Author', $result->tweets[1]->authorName);
     }
+
+    #[Test]
+    public function itReturnsUnknownWhenAuthorProfileIsMissing(): void
+    {
+        $authorId = '019b5f3f-d110-7908-9177-5df439942a8b';
+        $tweet = Tweet::create($authorId, 'A tweet');
+
+        $this->tweetRepository
+            ->expects(self::once())
+            ->method('getAllTweets')
+            ->willReturn([$tweet]);
+
+        $this->profileRepository
+            ->expects(self::once())
+            ->method('findAllByUserIds')
+            ->with([$authorId])
+            ->willReturn([]);
+
+        $result = $this->handler->handle(new GetTweetsCommand());
+
+        self::assertCount(1, $result->tweets);
+        self::assertSame(
+            GetTweetsCommandHandler::UNKNOWN_AUTHOR,
+            $result->tweets[0]->authorName,
+        );
+    }
 }


### PR DESCRIPTION
Closes #82 

## Description

Implement the missing `GetTweetsCommandHandlerInterface` to resolve a controller instantiation error and add a safe fallback for the `authorName` field using a new `UNKNOWN_AUTHOR` constant to prevent 500 errors when user profiles are missing.

## How to roll back?

Revert this pull request.

## How has this been tested?

```
$ docker compose exec php ./vendor/bin/phpunit tests/Tweet/Application/UseCase/GetTweets/GetTweetsCommandHandlerTest.php --testdox --display-phpunit-notices

PHPUnit 12.5.14 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.18
Configuration: /app/phpunit.dist.xml

....                                                                4 / 4 (100%)

Time: 00:00.017, Memory: 16.00 MB

Get Tweets Command Handler (Twitter\Tests\Tweet\Application\UseCase\GetTweets\GetTweetsCommandHandler)
 ✔ It returns empty list when no tweets exist
 ✔ It returns tweets with author data in same order
 ✔ It fetches author name only once per author id
 ✔ It returns unknown when author profile is missing

OK (4 tests, 32 assertions)
```

## Media attachments (optional)

<img width="1725" height="990" alt="image" src="https://github.com/user-attachments/assets/79d11a88-847e-4a7a-90fa-c3cc86e6d62b" />

