### PR TITLE
Scrum 111 grafana dashboards (MySQL + WEB)

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -73,6 +73,19 @@ services:
       retries: 5
       start_period: 60s
   
+  mysqld_exporter:
+    image: prom/mysqld-exporter:v0.15.1
+    restart: unless-stopped
+    volumes:
+      - ./infra/mysql-exporter/.my.cnf:/.my.cnf:ro
+    command:
+      - --config.my-cnf=/.my.cnf
+    depends_on:
+      database:
+        condition: service_healthy
+    ports:
+      - "9104:9104"
+  
   ###> symfony/mercure-bundle ###
   mercure:
     image: dunglas/mercure:latest

--- a/docs/k6-loadtest.md
+++ b/docs/k6-loadtest.md
@@ -1,8 +1,10 @@
 # k6 Load Test — Twitter
 
-This document explains how to prepare test data for k6, run the stress test, and fully remove all loadtest-related data afterwards.
+This document explains how to prepare test data for k6, run the stress test, and fully remove all loadtest-related data
+afterwards.
 
 Assumptions:
+
 - MySQL runs in Docker Compose as service `database`
 - Database: `app`
 - MySQL credentials: `app / !ChangeMe!`
@@ -18,103 +20,21 @@ docker compose up -d
 docker compose ps
 ```
 
-## 2) Create loadtest users
-Email pattern: loadtest_000001@local.test … loadtest_002000@local.test
-Password: Pa$$word1
+## 2) Create (if missing) N users for this RUN_ID, run loadtest (no auto-delete):
 
 ```bash
-HASH='$2y$12$d765Nx30xRCm/cttxY4kJ.OmA3k4Ptd.4wz48.9WNaAbLBUAGK5aa'
-for i in $(seq -w 1 2000); do
-  echo "INSERT INTO users (id, roles, email, password_hash, created_at, updated_at)
-        VALUES (UUID_TO_BIN(UUID()), '[\"ROLE_USER\"]', 'loadtest_${i}@local.test', '${HASH}', NOW(), NOW());"
-done | docker compose exec -T database mysql -uapp -p'!ChangeMe!' app
+   BASE_URL=https://localhost SEED_USERS=1 USERS_COUNT=2000 RUN_ID=20260305_001 k6 run loadtest-twitter.js
 ```
 
-Verify:
+## 3) Re-run loadtest with the same users:
 
 ```bash
-docker compose exec -T database mysql -uapp -p'!ChangeMe!' -e \
-"SELECT COUNT(*) AS cnt FROM app.users WHERE email LIKE 'loadtest_%';"
+   BASE_URL=https://localhost SEED_USERS=1 USERS_COUNT=2000 RUN_ID=20260305_001 k6 run loadtest-twitter.js
 ```
 
-
-## 3) Create profiles for loadtest users
-profiles.user_id has FK ON DELETE CASCADE to users.id, so profiles are removed automatically when users are deleted.
-Create profiles for all loadtest users that do not have a profile yet:
+## 4) Cleanup ONLY (special command):
 
 ```bash
-docker compose exec -T database mysql -uapp -p'!ChangeMe!' app -e "
-INSERT INTO profiles (user_id, name, bio, created_at, updated_at)
-SELECT u.id,
-       CONCAT('LoadUser ', SUBSTRING_INDEX(SUBSTRING_INDEX(u.email, '@', 1), '_', -1)),
-       'LOADTEST',
-       NOW(),
-       NOW()
-FROM users u
-LEFT JOIN profiles p ON p.user_id = u.id
-WHERE u.email LIKE 'loadtest_%'
-  AND p.user_id IS NULL;
-"
+   MODE=cleanup RUN_ID=20260305_001 k6 run loadtest-twitter.js
 ```
 
-Verify:
-
-```bash
-docker compose exec -T database mysql -uapp -p'!ChangeMe!' -e "
-SELECT
-  (SELECT COUNT(*) FROM app.users WHERE email LIKE 'loadtest_%') AS users_cnt,
-  (SELECT COUNT(*) FROM app.profiles WHERE user_id IN (SELECT id FROM app.users WHERE email LIKE 'loadtest_%')) AS profiles_cnt;
-"
-```
-
-## 4) Run the k6 test
-```bash
-k6 run loadtest-twitter.js
-```
-
-## 5) Cleanup — delete loadtest users and related data
-Schema facts:
-profiles.user_id has ON DELETE CASCADE → profiles are removed automatically
-tweets.user_id has ON DELETE CASCADE → tweets are removed automatically
-likes has no foreign keys → likes must be deleted manually
-Correct cleanup flow:
-delete likes:
-likes made by loadtest users
-likes on tweets that belong to loadtest users (if other users liked them)
-delete loadtest users (profiles + tweets are removed via cascades)
-
-```bash
-docker compose exec -T database mysql -uapp -p'!ChangeMe!' app -e "
--- Likes made by loadtest users
-DELETE FROM likes
-WHERE user_id IN (SELECT id FROM users WHERE email LIKE 'loadtest_%');
-
--- Likes on tweets of loadtest users (if other users liked them)
-DELETE FROM likes
-WHERE tweet_id IN (
-  SELECT t.id
-  FROM tweets t
-  JOIN users u ON u.id = t.user_id
-  WHERE u.email LIKE 'loadtest_%'
-);
-
--- Delete users (profiles + tweets are deleted via ON DELETE CASCADE)
-DELETE FROM users
-WHERE email LIKE 'loadtest_%';
-"
-```
-
-Verify:
-
-```bash
-docker compose exec -T database mysql -uapp -p'!ChangeMe!' -e \
-"SELECT COUNT(*) AS cnt FROM app.users WHERE email LIKE 'loadtest_%';"
-```
-
-## 6) Common issues
-
-### `Field 'updated_at' doesn't have a default value`
-Cause: `updated_at` is `NOT NULL` in `users` and `profiles`, and MySQL has no default value for it.  
-Fix: Always set `updated_at` explicitly in INSERTs (the commands above use `NOW()`).
-
----

--- a/infra/grafana/dashboards/mysql-dashboard.json
+++ b/infra/grafana/dashboards/mysql-dashboard.json
@@ -1,0 +1,814 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": false,
+        "iconColor": "#e0752d",
+        "limit": 100,
+        "name": "Annotations & Alerts",
+        "showIn": 0,
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "refresh": "",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "MySQL",
+    "Loadtest",
+    "Minimal"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allFormat": "glob",
+        "auto": true,
+        "auto_count": 200,
+        "auto_min": "1s",
+        "current": {
+          "selected": false,
+          "text": "auto",
+          "value": "$__auto_interval_interval"
+        },
+        "datasource": "prometheus",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Interval",
+        "multi": false,
+        "multiFormat": "glob",
+        "name": "interval",
+        "options": [
+          {
+            "selected": true,
+            "text": "auto",
+            "value": "$__auto_interval_interval"
+          },
+          {
+            "selected": false,
+            "text": "1s",
+            "value": "1s"
+          },
+          {
+            "selected": false,
+            "text": "5s",
+            "value": "5s"
+          },
+          {
+            "selected": false,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          }
+        ],
+        "query": "1s,5s,1m,5m,1h",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "type": "interval"
+      },
+      {
+        "allFormat": "glob",
+        "current": {
+          "selected": false,
+          "text": "mysqld_exporter:9104",
+          "value": "mysqld_exporter:9104"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Host",
+        "multi": false,
+        "multiFormat": "regex values",
+        "name": "host",
+        "options": [],
+        "query": "label_values(mysql_up, instance)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h"
+    ]
+  },
+  "timezone": "browser",
+  "title": "MySQL Overview",
+  "uid": "MQWgroiiz",
+  "version": 2,
+  "panels": [
+    {
+      "type": "row",
+      "title": "Overview",
+      "id": 1000,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "Uptime",
+      "id": 1,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "mysql_global_status_uptime{instance=\"$host\"}",
+          "format": "time_series",
+          "interval": "$interval"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "QPS",
+      "id": 2,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(mysql_global_status_queries{instance=\"$host\"}[$interval]) or irate(mysql_global_status_queries{instance=\"$host\"}[5m])",
+          "format": "time_series",
+          "interval": "$interval"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Threads running",
+      "id": 3,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "mysql_global_status_threads_running{instance=\"$host\"}",
+          "format": "time_series",
+          "interval": "$interval"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Threads connected (%)",
+      "id": 4,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(mysql_global_status_threads_connected{instance=\"$host\"} * 100) / mysql_global_variables_max_connections{instance=\"$host\"}",
+          "format": "time_series",
+          "interval": "$interval"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "InnoDB buffer pool size",
+      "id": 5,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 5
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "mysql_global_variables_innodb_buffer_pool_size{instance=\"$host\"}",
+          "format": "time_series",
+          "interval": "$interval"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Slow queries /s",
+      "id": 6,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 5
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(mysql_global_status_slow_queries{instance=\"$host\"}[$interval]) or irate(mysql_global_status_slow_queries{instance=\"$host\"}[5m])",
+          "format": "time_series",
+          "interval": "$interval"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Tmp disk tables /s",
+      "id": 7,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 5
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(mysql_global_status_created_tmp_disk_tables{instance=\"$host\"}[$interval]) or irate(mysql_global_status_created_tmp_disk_tables{instance=\"$host\"}[5m])",
+          "format": "time_series",
+          "interval": "$interval"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Aborted connects /s",
+      "id": 8,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 5
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(mysql_global_status_aborted_connects{instance=\"$host\"}[$interval]) or irate(mysql_global_status_aborted_connects{instance=\"$host\"}[5m])",
+          "format": "time_series",
+          "interval": "$interval"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Bottlenecks",
+      "id": 1001,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Connections",
+      "id": 20,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "mysql_global_status_threads_connected{instance=\"$host\"}",
+          "legendFormat": "threads_connected",
+          "format": "time_series",
+          "interval": "$interval"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "mysql_global_variables_max_connections{instance=\"$host\"}",
+          "legendFormat": "max_connections",
+          "format": "time_series",
+          "interval": "$interval"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "mysql_global_status_max_used_connections{instance=\"$host\"}",
+          "legendFormat": "max_used_connections",
+          "format": "time_series",
+          "interval": "$interval"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Threads running",
+      "id": 21,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "mysql_global_status_threads_running{instance=\"$host\"}",
+          "legendFormat": "threads_running",
+          "format": "time_series",
+          "interval": "$interval"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Table locks waited",
+      "id": 22,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(mysql_global_status_table_locks_waited{instance=\"$host\"}[$interval]) or irate(mysql_global_status_table_locks_waited{instance=\"$host\"}[5m])",
+          "legendFormat": "table_locks_waited/s",
+          "format": "time_series",
+          "interval": "$interval"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(mysql_global_status_table_locks_immediate{instance=\"$host\"}[$interval]) or irate(mysql_global_status_table_locks_immediate{instance=\"$host\"}[5m])",
+          "legendFormat": "table_locks_immediate/s",
+          "format": "time_series",
+          "interval": "$interval"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Network traffic",
+      "id": 23,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unitScale": true,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(mysql_global_status_bytes_received{instance=\"$host\"}[$interval]) or irate(mysql_global_status_bytes_received{instance=\"$host\"}[5m])",
+          "legendFormat": "in",
+          "format": "time_series",
+          "interval": "$interval"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(mysql_global_status_bytes_sent{instance=\"$host\"}[$interval]) or irate(mysql_global_status_bytes_sent{instance=\"$host\"}[5m])",
+          "legendFormat": "out",
+          "format": "time_series",
+          "interval": "$interval"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/twitter-web.json
+++ b/infra/grafana/dashboards/twitter-web.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -20,23 +23,40 @@
   "panels": [
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "id": 100,
       "panels": [],
       "title": "Traffic",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "orange", "value": 1 },
-              { "color": "red", "value": 5 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
             ]
           },
           "unit": "percent",
@@ -44,14 +64,25 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 3, "w": 8, "x": 0, "y": 1 },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
       "id": 2,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "showPercentChange": false,
         "textMode": "auto",
         "wideLayout": true
@@ -59,9 +90,12 @@
       "pluginVersion": "10.3.3",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
-          "expr": "100 * sum(rate(http_requests_total{status=~\"5..\",route!~\"^(metrics|api_health_check)$\"}[1m])) / clamp_min(sum(rate(http_requests_total{route!~\"^(metrics|api_health_check)$\"}[1m])), 1)",
+          "expr": "100 * (\n  sum(rate(http_requests_total{status=~\"5..\",route!~\"^(metrics|api_health_check)$\"}[1m])) or vector(0)\n) / clamp_min(\n  (sum(rate(http_requests_total{route!~\"^(metrics|api_health_check)$\"}[1m])) or vector(0)),\n  1\n)",
           "range": true,
           "refId": "A"
         }
@@ -70,16 +104,28 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "orange", "value": 1 },
-              { "color": "red", "value": 5 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
             ]
           },
           "unit": "percent",
@@ -87,14 +133,25 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 3, "w": 8, "x": 8, "y": 1 },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
       "id": 8,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "showPercentChange": false,
         "textMode": "auto",
         "wideLayout": true
@@ -102,9 +159,12 @@
       "pluginVersion": "10.3.3",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
-          "expr": "100 * sum(rate(http_requests_total{status=~\"4..\",route!~\"^(metrics|api_health_check)$\"}[1m])) / clamp_min(sum(rate(http_requests_total{route!~\"^(metrics|api_health_check)$\"}[1m])), 1)",
+          "expr": "100 * (\n  sum(rate(http_requests_total{status=~\"4..\",route!~\"^(metrics|api_health_check)$\"}[1m])) or vector(0)\n) / clamp_min(\n  (sum(rate(http_requests_total{route!~\"^(metrics|api_health_check)$\"}[1m])) or vector(0)),\n  1\n)",
           "range": true,
           "refId": "A"
         }
@@ -113,30 +173,53 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "orange", "value": 1 },
-              { "color": "red", "value": 10 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
             ]
           },
           "unitScale": true
         },
         "overrides": []
       },
-      "gridPos": { "h": 3, "w": 8, "x": 16, "y": 1 },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
       "id": 3,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "showPercentChange": false,
         "textMode": "auto",
         "wideLayout": true
@@ -144,9 +227,12 @@
       "pluginVersion": "10.3.3",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
-          "expr": "sum(rate(http_rate_limited_total{route!~\"^(metrics|api_health_check)$\"}[1m])) * 60",
+          "expr": "60 * (\n  sum(rate(http_requests_total{status=\"429\",route!~\"^(metrics|api_health_check)$\"}[1m])) or vector(0)\n)",
           "range": true,
           "refId": "A"
         }
@@ -155,10 +241,15 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -169,37 +260,73 @@
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "min": 0,
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 80 }]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
           },
           "unit": "req/s",
           "unitScale": false
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
       "id": 1,
       "options": {
-        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
-        "tooltip": { "mode": "single", "sort": "none" }
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
           "expr": "sum by (route) (rate(http_requests_total{route!~\"^(metrics|api_health_check)$\"}[30s]))",
           "legendFormat": "{{route}}",
@@ -211,10 +338,15 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -225,36 +357,72 @@
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
           },
           "unit": "s",
           "unitScale": false
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
       "id": 4,
       "options": {
-        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
-        "tooltip": { "mode": "single", "sort": "none" }
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
           "expr": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket{route!~\"^(metrics|api_health_check)$\"}[1m])))",
           "legendFormat": "{{route}}",
@@ -266,10 +434,15 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -280,38 +453,74 @@
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
           },
           "unit": "ms",
           "unitScale": false
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
       "id": 9,
       "options": {
-        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
-        "tooltip": { "mode": "single", "sort": "none" }
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
-          "expr": "1000 * sum by (route) (rate(http_request_duration_seconds_sum{route!~\"^(metrics|api_health_check)$\"}[1m])) / clamp_min(sum by (route) (rate(http_request_duration_seconds_count{route!~\"^(metrics|api_health_check)$\"}[1m])), 1e-9)",
+          "expr": "1000 *\nsum by (route) (increase(http_request_duration_seconds_sum{route!~\"^(metrics|api_health_check)$\"}[1m]))\n/ clamp_min(\n  sum by (route) (increase(http_request_duration_seconds_count{route!~\"^(metrics|api_health_check)$\"}[1m])),\n  1\n)",
           "legendFormat": "{{route}}",
           "range": true,
           "refId": "A"
@@ -321,10 +530,15 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -335,36 +549,72 @@
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1.5 }]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1.5
+              }
+            ]
           },
           "unit": "s",
           "unitScale": false
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
       "id": 7,
       "options": {
-        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
-        "tooltip": { "mode": "single", "sort": "none" }
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
           "expr": "histogram_quantile(0.99, sum by (le, route) (rate(http_request_duration_seconds_bucket{route!~\"^(metrics|api_health_check)$\"}[1m])))",
           "legendFormat": "{{route}}",
@@ -376,31 +626,69 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 80 }]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
           },
           "unitScale": true
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 20 },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
       "id": 5,
       "options": {
         "cellHeight": "sm",
-        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
         "showHeader": true,
-        "sortBy": [{ "desc": false, "displayName": "status" }]
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "status"
+          }
+        ]
       },
       "pluginVersion": "10.3.3",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
           "expr": "sum by (route, status) (increase(http_requests_total{route!~\"^(metrics|api_health_check)$\"}[1m]))",
           "format": "table",
@@ -414,13 +702,22 @@
   ],
   "refresh": "5s",
   "schemaVersion": 39,
-  "tags": ["twitter", "web", "api"],
-  "templating": { "list": [] },
-  "time": { "from": "now-15m", "to": "now" },
+  "tags": [
+    "twitter",
+    "web",
+    "api"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "browser",
   "title": "Twitter – Web/API",
   "uid": "twitter-web",
-  "version": 5,
+  "version": 6,
   "weekStart": ""
 }

--- a/infra/mysql-exporter/.my.cnf
+++ b/infra/mysql-exporter/.my.cnf
@@ -1,0 +1,5 @@
+[client]
+user=app
+password=!ChangeMe!
+host=database
+port=3306

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -15,3 +15,7 @@ scrape_configs:
       static_configs:
           - targets:
                 - rabbitmq:15692
+
+    - job_name: mysql
+      static_configs:
+          - targets: [ "mysqld_exporter:9104" ]

--- a/loadtest-twitter.js
+++ b/loadtest-twitter.js
@@ -8,28 +8,47 @@ import driver from 'k6/x/sql/driver/mysql';
    🔧 CONFIG
 ========================= */
 
-const MySQL_USER = 'app';
-const MySQL_PASSWORD = '!ChangeMe!';
-const MySQL_IP = '127.0.0.1';
-const MySQL_PORT = '3306';
-const MySQL_DATABASE = 'app';
+const MySQL_USER = __ENV.MYSQL_USER || 'app';
+const MySQL_PASSWORD = __ENV.MYSQL_PASSWORD || '!ChangeMe!';
+const MySQL_IP = __ENV.MYSQL_IP || '127.0.0.1';
+const MySQL_PORT = __ENV.MYSQL_PORT || '3306';
+const MySQL_DATABASE = __ENV.MYSQL_DATABASE || 'app';
 
 const db = sql.open(
   driver,
   `${MySQL_USER}:${MySQL_PASSWORD}@tcp(${MySQL_IP}:${MySQL_PORT})/${MySQL_DATABASE}`
 );
 
-const BASE_URL = 'https://localhost';
+const BASE_URL = __ENV.BASE_URL || 'https://localhost';
 
-const FEED_LIMIT = 50;
-const maxFeedPages = 7;
-const scrollProbability = 0.9;
+const FEED_LIMIT = parseInt(__ENV.FEED_LIMIT || '50', 10);
+const maxFeedPages = parseInt(__ENV.FEED_PAGES || '7', 10);
+const scrollProbability = parseFloat(__ENV.SCROLL_PROB || '0.9');
 
-const THINK_TIME_MIN = 0;
-const THINK_TIME_MAX = 0;
+const THINK_TIME_MIN = parseFloat(__ENV.THINK_TIME_MIN || '0');
+const THINK_TIME_MAX = parseFloat(__ENV.THINK_TIME_MAX || '0');
 
-const JWT_TTL_SECONDS = 900;
-const JWT_REFRESH_SAFETY_SECONDS = 60;
+const JWT_TTL_SECONDS = parseInt(__ENV.JWT_TTL_SECONDS || '900', 10);
+const JWT_REFRESH_SAFETY_SECONDS = parseInt(__ENV.JWT_REFRESH_SAFETY_SECONDS || '60', 10);
+
+/* =========================
+   🌱 MODE / SEED
+========================= */
+
+const MODE = __ENV.MODE || 'loadtest'; // loadtest | cleanup
+
+const SEED_USERS = (__ENV.SEED_USERS || '0') === '1';
+const USERS_COUNT = parseInt(__ENV.USERS_COUNT || '2000', 10);
+
+const RUN_ID = __ENV.RUN_ID || `${Date.now()}`;
+const EMAIL_PREFIX = `loadtest_${RUN_ID}_`;
+const EMAIL_LIKE = `${EMAIL_PREFIX}%`;
+
+const PLAIN_PASSWORD = __ENV.LOADTEST_PASSWORD || 'Pa$$word1';
+
+const PASSWORD_HASH =
+  __ENV.PASSWORD_HASH ||
+  '$2y$12$d765Nx30xRCm/cttxY4kJ.OmA3k4Ptd.4wz48.9WNaAbLBUAGK5aa';
 
 /* =========================
    📊 OPTIONS
@@ -46,82 +65,96 @@ const endpoints = [
   'Login',
 ];
 
-export const options = {
-  insecureSkipTLSVerify: true,
+export const options =
+  MODE === 'cleanup'
+    ? {
+      insecureSkipTLSVerify: true,
+      scenarios: {
+        cleanup: {
+          executor: 'per-vu-iterations',
+          vus: 1,
+          iterations: 1,
+          exec: 'scenarioCleanup',
+        },
+      },
+    }
+    : {
+      insecureSkipTLSVerify: true,
 
-  scenarios: {
-    auth_stress: {
-      executor: 'ramping-vus',
-      exec: 'scenarioAuth',
-      stages: [
-        { duration: '10s', target: 3 },
-        { duration: '3m', target: 3 },
-        { duration: '3m', target: 3 },
-        { duration: '1m', target: 3 },
-      ],
-      gracefulRampDown: '30s',
-      gracefulStop: '30s',
-    },
+      scenarios: {
+        auth_stress: {
+          executor: 'ramping-vus',
+          exec: 'scenarioAuth',
+          stages: [
+            { duration: '10s', target: 3 },
+            { duration: '3m', target: 3 },
+            { duration: '3m', target: 3 },
+            { duration: '1m', target: 3 },
+          ],
+          gracefulRampDown: '30s',
+          gracefulStop: '30s',
+        },
 
-    feed_stress: {
-      executor: 'ramping-vus',
-      exec: 'scenarioFeed',
-      stages: [
-        { duration: '10s', target: 6 },
-        { duration: '3m', target: 6 },
-        { duration: '3m', target: 6 },
-        { duration: '1m', target: 6 },
-      ],
-      gracefulRampDown: '30s',
-      gracefulStop: '30s',
-    },
+        feed_stress: {
+          executor: 'ramping-vus',
+          exec: 'scenarioFeed',
+          stages: [
+            { duration: '10s', target: 6 },
+            { duration: '3m', target: 6 },
+            { duration: '3m', target: 6 },
+            { duration: '1m', target: 6 },
+          ],
+          gracefulRampDown: '30s',
+          gracefulStop: '30s',
+        },
 
-    profile_stress: {
-      executor: 'ramping-vus',
-      exec: 'scenarioProfile',
-      stages: [
-        { duration: '10s', target: 3 },
-        { duration: '3m', target: 3 },
-        { duration: '3m', target: 3 },
-        { duration: '1m', target: 3 },
-      ],
-      gracefulRampDown: '30s',
-      gracefulStop: '30s',
-    },
+        profile_stress: {
+          executor: 'ramping-vus',
+          exec: 'scenarioProfile',
+          stages: [
+            { duration: '10s', target: 3 },
+            { duration: '3m', target: 3 },
+            { duration: '3m', target: 3 },
+            { duration: '1m', target: 3 },
+          ],
+          gracefulRampDown: '30s',
+          gracefulStop: '30s',
+        },
 
-    like_stress: {
-      executor: 'ramping-vus',
-      exec: 'scenarioLike',
-      stages: [
-        { duration: '10s', target: 2 },
-        { duration: '3m', target: 2 },
-        { duration: '3m', target: 2 },
-        { duration: '1m', target: 2 },
-      ],
-      gracefulRampDown: '30s',
-      gracefulStop: '30s',
-    },
-  },
+        like_stress: {
+          executor: 'ramping-vus',
+          exec: 'scenarioLike',
+          stages: [
+            { duration: '10s', target: 2 },
+            { duration: '3m', target: 2 },
+            { duration: '3m', target: 2 },
+            { duration: '1m', target: 2 },
+          ],
+          gracefulRampDown: '30s',
+          gracefulStop: '30s',
+        },
+      },
 
-  thresholds: {
-    http_req_failed: ['rate<0.01'],
-    http_req_waiting: ['p(95)<10000'],
-    ...endpoints.reduce(
-      (acc, endpoint) => ({
-        ...acc,
-        [`http_req_duration{endpoint:${endpoint}}`]: ['p(95)<10000'],
-        [`http_reqs{endpoint:${endpoint}}`]: ['count>=0'],
-      }),
-      {}
-    ),
-  },
-};
+      thresholds: {
+        http_req_failed: ['rate<0.01'],
+        http_req_waiting: ['p(95)<10000'],
+        ...endpoints.reduce(
+          (acc, endpoint) => ({
+            ...acc,
+            [`http_req_duration{endpoint:${endpoint}}`]: ['p(95)<10000'],
+            [`http_reqs{endpoint:${endpoint}}`]: ['count>=0'],
+          }),
+          {}
+        ),
+      },
+    };
 
 /* =========================
-   📦 DATA LOAD
+   📦 HELPERS (common)
 ========================= */
 
 function asciiRowToString(v) {
+  if (typeof v === 'string') return v;
   return String.fromCharCode(...v);
 }
 
@@ -130,43 +163,6 @@ function mustNotBeEmpty(arr, name) {
     throw new Error(`[TEST DATA] ${name} is empty`);
   }
 }
-
-let rows;
-
-let emailsAvailable = [];
-rows = db.query("SELECT email FROM app.users WHERE email LIKE 'loadtest_%' LIMIT 10000;");
-for (const row of rows) emailsAvailable.push(asciiRowToString(row.email));
-
-let profilesAvailable = [];
-rows = db.query(`
-  SELECT BIN_TO_UUID(user_id) AS profile_uuid
-  FROM app.profiles
-  WHERE user_id IN (SELECT id FROM app.users WHERE email LIKE 'loadtest_%')
-    LIMIT 10000;
-`);
-for (const row of rows) profilesAvailable.push(asciiRowToString(row.profile_uuid));
-
-let tweetsAvailable = [];
-rows = db.query('SELECT BIN_TO_UUID(id) as tweet_id FROM app.tweets LIMIT 10000;');
-for (const row of rows) tweetsAvailable.push(asciiRowToString(row.tweet_id));
-
-mustNotBeEmpty(emailsAvailable, 'emailsAvailable (loadtest users)');
-mustNotBeEmpty(profilesAvailable, 'profilesAvailable (loadtest profiles)');
-mustNotBeEmpty(tweetsAvailable, 'tweetsAvailable (tweets)');
-
-if (__VU === 1) {
-  console.log(
-    `#TEST DATA# Loadtest Emails: ${emailsAvailable.length} | Loadtest Profiles: ${profilesAvailable.length} | TweetsToLike: ${tweetsAvailable.length}`
-  );
-}
-
-export function teardown() {
-  db.close();
-}
-
-/* =========================
-   🛠 HELPERS
-========================= */
 
 function randomItem(arr) {
   return arr[Math.floor(Math.random() * arr.length)];
@@ -186,13 +182,111 @@ function nowSeconds() {
 }
 
 /* =========================
+   🌱 SEED IMPLEMENTATION
+========================= */
+
+function seedLoadtestUsers(count) {
+  const rows = db.query('SELECT COUNT(*) AS cnt FROM app.users WHERE email LIKE ?;', EMAIL_LIKE);
+  const existing = Number(rows[0].cnt);
+
+  if (existing >= count) return;
+
+  for (let i = existing + 1; i <= count; i++) {
+    const n = String(i).padStart(6, '0');
+    const email = `${EMAIL_PREFIX}${n}@local.test`;
+
+    db.exec(
+      `INSERT INTO app.users (id, roles, email, password_hash, created_at, updated_at)
+       VALUES (UUID_TO_BIN(UUID()), '["ROLE_USER"]', ?, ?, NOW(), NOW());`,
+      email,
+      PASSWORD_HASH
+    );
+  }
+}
+
+function seedProfilesForLoadtestUsers() {
+  db.exec(
+    `INSERT INTO app.profiles (user_id, name, bio, created_at, updated_at)
+     SELECT u.id,
+            CONCAT('LoadUser ', SUBSTRING_INDEX(SUBSTRING_INDEX(u.email, '@', 1), '_', -1)),
+            'LOADTEST',
+            NOW(),
+            NOW()
+     FROM app.users u
+     LEFT JOIN app.profiles p ON p.user_id = u.id
+     WHERE u.email LIKE ?
+       AND p.user_id IS NULL;`,
+    EMAIL_LIKE
+  );
+}
+
+function loadTestData() {
+  let rows;
+
+  const emailsAvailable = [];
+  rows = db.query('SELECT email FROM app.users WHERE email LIKE ? LIMIT 10000;', EMAIL_LIKE);
+  for (const row of rows) emailsAvailable.push(asciiRowToString(row.email));
+
+  const profilesAvailable = [];
+  rows = db.query(
+    `SELECT BIN_TO_UUID(user_id) AS profile_uuid
+     FROM app.profiles
+     WHERE user_id IN (SELECT id FROM app.users WHERE email LIKE ?)
+     LIMIT 10000;`,
+    EMAIL_LIKE
+  );
+  for (const row of rows) profilesAvailable.push(asciiRowToString(row.profile_uuid));
+
+  const tweetsAvailable = [];
+  rows = db.query('SELECT BIN_TO_UUID(id) as tweet_id FROM app.tweets LIMIT 10000;');
+  for (const row of rows) tweetsAvailable.push(asciiRowToString(row.tweet_id));
+
+  mustNotBeEmpty(emailsAvailable, 'emailsAvailable (loadtest users)');
+  mustNotBeEmpty(profilesAvailable, 'profilesAvailable (loadtest profiles)');
+  mustNotBeEmpty(tweetsAvailable, 'tweetsAvailable (tweets)');
+
+  console.log(
+    `#TEST DATA# Mode=${MODE} RunId=${RUN_ID} | Emails=${emailsAvailable.length} | Profiles=${profilesAvailable.length} | TweetsToLike=${tweetsAvailable.length}`
+  );
+
+  return { emailsAvailable, profilesAvailable, tweetsAvailable };
+}
+
+/* =========================
+   ✅ SETUP / TEARDOWN
+========================= */
+
+export function setup() {
+  if (MODE === 'cleanup') {
+    return { emailLike: EMAIL_LIKE, runId: RUN_ID };
+  }
+
+  if (SEED_USERS) {
+    seedLoadtestUsers(USERS_COUNT);
+    seedProfilesForLoadtestUsers();
+  }
+
+  const data = loadTestData();
+  return {
+    runId: RUN_ID,
+    emailPrefix: EMAIL_PREFIX,
+    emailLike: EMAIL_LIKE,
+    ...data,
+  };
+}
+
+export function teardown() {
+  db.close();
+}
+
+/* =========================
    🔐 AUTH
 ========================= */
 
-function login() {
+function login(emailsAvailable) {
   const payload = JSON.stringify({
     email: randomItem(emailsAvailable),
-    password: 'Pa$$word1',
+    password: PLAIN_PASSWORD,
   });
 
   const params = {
@@ -229,9 +323,9 @@ function jwtExpiredOrSoon() {
   return age >= JWT_TTL_SECONDS - JWT_REFRESH_SAFETY_SECONDS;
 }
 
-function getJwtOncePerVu() {
+function getJwtOncePerVu(emailsAvailable) {
   if (!jwtCache || jwtExpiredOrSoon()) {
-    jwtCache = login();
+    jwtCache = login(emailsAvailable);
     jwtCacheCreatedAt = nowSeconds();
   }
   return jwtCache;
@@ -274,7 +368,7 @@ function mainFeed(jwt) {
    👤 PROFILE
 ========================= */
 
-function getProfile(jwt) {
+function getProfile(jwt, profilesAvailable) {
   const profileId = randomItem(profilesAvailable);
 
   group('GET /api/profiles/{id}', () => {
@@ -306,7 +400,7 @@ function getProfile(jwt) {
    ❤️ LIKE
 ========================= */
 
-function toggleLike(jwt) {
+function toggleLike(jwt, tweetsAvailable) {
   const tweetId = randomItem(tweetsAvailable);
 
   group('POST /api/tweets/{id}/likes/toggle', () => {
@@ -323,35 +417,63 @@ function toggleLike(jwt) {
 }
 
 /* =========================
+   🧹 CLEANUP SCENARIO
+========================= */
+
+export function scenarioCleanup(data) {
+  const like = data.emailLike;
+
+  const r1 = db.query('SELECT COUNT(*) AS cnt FROM app.users WHERE email LIKE ?;', like);
+  const users = Number(r1[0].cnt);
+
+  const r2 = db.query(
+    'SELECT COUNT(*) AS cnt FROM app.profiles WHERE user_id IN (SELECT id FROM app.users WHERE email LIKE ?);',
+    like
+  );
+  const profiles = Number(r2[0].cnt);
+
+  console.log(`#CLEANUP# Found users=${users}, profiles=${profiles}, like=${like}`);
+
+  db.exec(
+    'DELETE FROM app.profiles WHERE user_id IN (SELECT id FROM app.users WHERE email LIKE ?);',
+    like
+  );
+  db.exec('DELETE FROM app.users WHERE email LIKE ?;', like);
+
+  const r3 = db.query('SELECT COUNT(*) AS cnt FROM app.users WHERE email LIKE ?;', like);
+  console.log(`#CLEANUP# Remaining users=${Number(r3[0].cnt)} for like=${like}`);
+}
+
+/* =========================
    🚶 SCENARIOS
 ========================= */
 
-export function scenarioAuth() {
-  login();
+export function scenarioAuth(data) {
+  login(data.emailsAvailable);
   randomSleep();
 }
 
-export function scenarioFeed() {
+export function scenarioFeed(data) {
   mainFeed(null);
-  const jwt = getJwtOncePerVu();
+  const jwt = getJwtOncePerVu(data.emailsAvailable);
   mainFeed(jwt);
   randomSleep();
 }
 
-export function scenarioProfile() {
-  const jwt = getJwtOncePerVu();
+export function scenarioProfile(data) {
+  const jwt = getJwtOncePerVu(data.emailsAvailable);
   const views = 3 + Math.floor(Math.random() * 6);
   for (let i = 0; i < views; i++) {
-    getProfile(jwt);
+    getProfile(jwt, data.profilesAvailable);
     randomSleep();
   }
 }
 
-export function scenarioLike() {
-  const jwt = getJwtOncePerVu();
+export function scenarioLike(data) {
+  const jwt = getJwtOncePerVu(data.emailsAvailable);
   const likes = 5 + Math.floor(Math.random() * 8);
   for (let i = 0; i < likes; i++) {
-    toggleLike(jwt);
+    toggleLike(jwt, data.tweetsAvailable);
     randomSleep();
   }
 }


### PR DESCRIPTION
Description

Added MySQL observability:
Introduced mysqld_exporter (configured via infra/mysql-exporter/.my.cnf) and wired it into compose.yaml.
Updated Prometheus config to scrape MySQL exporter metrics.
Added a minimal “MySQL Overview” Grafana dashboard (replacing the noisy default with only key KPIs and bottleneck charts).
Improved Grafana “Twitter – Web/API” dashboard stability:
Fixed 5xx/4xx/429 panels to return 0 instead of “No data” when there are no errors (using safe PromQL fallback).
Stabilized “Avg latency by route” to avoid extreme spikes (years) under low traffic by using a safer aggregation approach.
Updated k6 load test runner:
Added seeding and cleanup modes for loadtest_* users/profiles directly in loadtest-twitter.js to make runs reproducible without manual DB prep.

How to roll back?

Revert this pull request.

Media attachments

<img width="1728" height="862" alt="Знімок екрана 2026-03-05 о 20 30 33" src="https://github.com/user-attachments/assets/6f00b1f1-174d-4f9b-8199-b8c5192ae946" />
<img width="1728" height="889" alt="Знімок екрана 2026-03-05 о 20 31 13" src="https://github.com/user-attachments/assets/36739837-d8de-45f7-8403-d0ab5d5a4c53" />
