### PR TITLE
feat(registration): SCRUM-112 Send Email on Successful Registration

### DIFF
--- a/.env
+++ b/.env
@@ -70,3 +70,7 @@ RATE_LIMIT_TWEET_CREATE=10
 RATE_LIMIT_LIKE=20
 RATE_LIMIT_LOGIN=5
 ###< Redis & Caching Infrastructure ###
+
+###> symfony/mailer ###
+MAILER_DSN=null://null
+###< symfony/mailer ###

--- a/.env
+++ b/.env
@@ -72,4 +72,5 @@ RATE_LIMIT_LOGIN=5
 
 ###> symfony/mailer ###
 MAILER_DSN=null://null
+MAILER_SENDER=noreply@twitter.local
 ###< symfony/mailer ###

--- a/.env
+++ b/.env
@@ -53,7 +53,6 @@ MERCURE_PUBLIC_URL=/.well-known/mercure
 MERCURE_JWT_SECRET="!ChangeThisMercureHubJWTSecretKey!"
 ###< symfony/mercure-bundle ###
 
-
 RABBITMQ_DEFAULT_USER="app"
 RABBITMQ_DEFAULT_PASS="app"
 

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -35,3 +35,14 @@ services:
     ports:
       - "80"
 ###< symfony/mercure-bundle ###
+
+###> symfony/mailer ###
+  mailer:
+    image: axllent/mailpit
+    ports:
+      - "1025"
+      - "8025"
+    environment:
+      MP_SMTP_AUTH_ACCEPT_ANY: 1
+      MP_SMTP_AUTH_ALLOW_INSECURE: 1
+###< symfony/mailer ###

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,6 +7,8 @@ services:
         condition: service_healthy
       rabbitmq:
         condition: service_started
+      mailpit:
+        condition: service_started
     environment:
       APP_ENV: dev
       APP_DEBUG: 1
@@ -19,6 +21,7 @@ services:
       MERCURE_PUBLIC_URL: ${MERCURE_PUBLIC_URL:-/.well-known/mercure}
       MERCURE_JWT_SECRET: ${MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
       MESSENGER_TRANSPORT_DSN: amqp://${RABBITMQ_DEFAULT_USER:-app}:${RABBITMQ_DEFAULT_PASS:-app}@rabbitmq:5672/%2f/messages
+      MAILER_DSN: smtp://mailpit:1025
     volumes:
       - caddy_data:/data
       - caddy_config:/config
@@ -40,6 +43,8 @@ services:
         condition: service_healthy
       rabbitmq:
         condition: service_started
+      mailpit:
+        condition: service_started
     environment:
       APP_ENV: dev
       DATABASE_URL: mysql://${MYSQL_USER:-app}:${MYSQL_PASSWORD:-!ChangeMe!}@database:3306/${MYSQL_DATABASE:-app}?serverVersion=${MYSQL_VERSION:-8}&charset=${MYSQL_CHARSET:-utf8mb4}
@@ -47,9 +52,10 @@ services:
       MERCURE_URL: ${MERCURE_URL:-http://mercure/.well-known/mercure}
       MERCURE_JWT_SECRET: ${MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
       DEFAULT_URI: https://${SERVER_NAME:-localhost}:${HTTPS_PORT:-443}
-    command: [ "php", "bin/console", "messenger:consume", "async", "--time-limit=3600", "--memory-limit=128M", "-vv" ]
+      MAILER_DSN: smtp://mailpit:1025
+    command: [ "php", "bin/console", "messenger:consume", "async", "async_emails", "--time-limit=3600", "--memory-limit=128M", "-vv" ]
     healthcheck:
-      test: ["CMD-SHELL", "grep -qa messenger /proc/1/cmdline"]
+      test: [ "CMD-SHELL", "grep -qa messenger /proc/1/cmdline" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -133,6 +139,13 @@ services:
       - "15672:15672" # management UI
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
+
+  mailpit:
+    image: axllent/mailpit:latest
+    restart: unless-stopped
+    ports:
+      - "8025:8025"   # web UI
+      - "1025:1025"   # SMTP
 
   prometheus:
     image: prom/prometheus:v2.50.1

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "symfony/flex": "^2.10",
         "symfony/framework-bundle": "7.4.*",
         "symfony/lock": "7.4.*",
+        "symfony/mailer": "7.4.*",
         "symfony/mercure-bundle": ">=0.4.2",
         "symfony/messenger": "7.4.*",
         "symfony/monolog-bundle": "^4.0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "662f66106c171cea4c921954e4b14edb",
+    "content-hash": "4a5018ded4adbf1ebbc4a041fbfacda4",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1178,6 +1178,73 @@
                 "source": "https://github.com/doctrine/sql-formatter/tree/1.5.4"
             },
             "time": "2026-02-08T16:21:46+00:00"
+        },
+        {
+            "name": "egulias/email-validator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/egulias/EmailValidator.git",
+                "reference": "d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa",
+                "reference": "d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^2.0 || ^3.0",
+                "php": ">=8.1",
+                "symfony/polyfill-intl-idn": "^1.26"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.2",
+                "vimeo/psalm": "^5.12"
+            },
+            "suggest": {
+                "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Egulias\\EmailValidator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eduardo Gulias Davis"
+                }
+            ],
+            "description": "A library for validating emails against several RFCs",
+            "homepage": "https://github.com/egulias/EmailValidator",
+            "keywords": [
+                "email",
+                "emailvalidation",
+                "emailvalidator",
+                "validation",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/egulias/EmailValidator/issues",
+                "source": "https://github.com/egulias/EmailValidator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/egulias",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-06T22:45:56+00:00"
         },
         {
             "name": "gesdinet/jwt-refresh-token-bundle",
@@ -4530,6 +4597,90 @@
             "time": "2026-02-17T07:53:42+00:00"
         },
         {
+            "name": "symfony/mailer",
+            "version": "v7.4.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mailer.git",
+                "reference": "b02726f39a20bc65e30364f5c750c4ddbf1f58e9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/b02726f39a20bc65e30364f5c750c4ddbf1f58e9",
+                "reference": "b02726f39a20bc65e30364f5c750c4ddbf1f58e9",
+                "shasum": ""
+            },
+            "require": {
+                "egulias/email-validator": "^2.1.10|^3|^4",
+                "php": ">=8.2",
+                "psr/event-dispatcher": "^1",
+                "psr/log": "^1|^2|^3",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/mime": "^7.2|^8.0",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/http-client-contracts": "<2.5",
+                "symfony/http-kernel": "<6.4",
+                "symfony/messenger": "<6.4",
+                "symfony/mime": "<6.4",
+                "symfony/twig-bridge": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/http-client": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/twig-bridge": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mailer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps sending emails",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/mailer/tree/v7.4.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-25T16:50:00+00:00"
+        },
+        {
             "name": "symfony/mercure",
             "version": "v0.7.2",
             "source": {
@@ -4788,6 +4939,95 @@
                 }
             ],
             "time": "2026-03-04T13:54:41+00:00"
+        },
+        {
+            "name": "symfony/mime",
+            "version": "v7.4.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mime.git",
+                "reference": "da5ab4fde3f6c88ab06e96185b9922f48b677cd1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/da5ab4fde3f6c88ab06e96185b9922f48b677cd1",
+                "reference": "da5ab4fde3f6c88ab06e96185b9922f48b677cd1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-intl-idn": "^1.10",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "conflict": {
+                "egulias/email-validator": "~3.0.0",
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1",
+                "symfony/mailer": "<6.4",
+                "symfony/serializer": "<6.4.3|>7.0,<7.0.3"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.1.10|^3.1|^4",
+                "league/html-to-markdown": "^5.0",
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/property-info": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4.3|^7.0.3|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mime\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows manipulating MIME messages",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "mime",
+                "mime-type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/mime/tree/v7.4.7"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-05T15:24:09+00:00"
         },
         {
             "name": "symfony/monolog-bridge",

--- a/composer.lock
+++ b/composer.lock
@@ -2603,16 +2603,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "1d06192e8f164e2729b0031e6807d72a6195b8bb"
+                "reference": "665522ec357540e66c294c08583b40ee576574f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/1d06192e8f164e2729b0031e6807d72a6195b8bb",
-                "reference": "1d06192e8f164e2729b0031e6807d72a6195b8bb",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/665522ec357540e66c294c08583b40ee576574f0",
+                "reference": "665522ec357540e66c294c08583b40ee576574f0",
                 "shasum": ""
             },
             "require": {
@@ -2683,7 +2683,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v7.4.6"
+                "source": "https://github.com/symfony/cache/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -2703,7 +2703,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-21T23:29:27+00:00"
+            "time": "2026-03-06T08:14:57+00:00"
         },
         {
             "name": "symfony/cache-contracts",
@@ -2861,16 +2861,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "9400e2f9226b3b64ebb0a8ae967ae84e54e39640"
+                "reference": "6c17162555bfb58957a55bb0e43e00035b6ae3d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/9400e2f9226b3b64ebb0a8ae967ae84e54e39640",
-                "reference": "9400e2f9226b3b64ebb0a8ae967ae84e54e39640",
+                "url": "https://api.github.com/repos/symfony/config/zipball/6c17162555bfb58957a55bb0e43e00035b6ae3d5",
+                "reference": "6c17162555bfb58957a55bb0e43e00035b6ae3d5",
                 "shasum": ""
             },
             "require": {
@@ -2916,7 +2916,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v7.4.6"
+                "source": "https://github.com/symfony/config/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -2936,20 +2936,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T16:50:00+00:00"
+            "time": "2026-03-06T10:41:14+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "6d643a93b47398599124022eb24d97c153c12f27"
+                "reference": "e1e6770440fb9c9b0cf725f81d1361ad1835329d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/6d643a93b47398599124022eb24d97c153c12f27",
-                "reference": "6d643a93b47398599124022eb24d97c153c12f27",
+                "url": "https://api.github.com/repos/symfony/console/zipball/e1e6770440fb9c9b0cf725f81d1361ad1835329d",
+                "reference": "e1e6770440fb9c9b0cf725f81d1361ad1835329d",
                 "shasum": ""
             },
             "require": {
@@ -3014,7 +3014,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.6"
+                "source": "https://github.com/symfony/console/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -3034,20 +3034,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T17:02:47+00:00"
+            "time": "2026-03-06T14:06:20+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "a3f7d594ca53a34a7d39ae683fbca09408b0c598"
+                "reference": "0f651e58f4917fb0e2cd261ccbfe3d71e6e0f5db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/a3f7d594ca53a34a7d39ae683fbca09408b0c598",
-                "reference": "a3f7d594ca53a34a7d39ae683fbca09408b0c598",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/0f651e58f4917fb0e2cd261ccbfe3d71e6e0f5db",
+                "reference": "0f651e58f4917fb0e2cd261ccbfe3d71e6e0f5db",
                 "shasum": ""
             },
             "require": {
@@ -3098,7 +3098,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.6"
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -3118,7 +3118,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T16:50:00+00:00"
+            "time": "2026-03-03T07:48:48+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3189,16 +3189,16 @@
         },
         {
             "name": "symfony/doctrine-bridge",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/doctrine-bridge.git",
-                "reference": "710cb7313446aa5ce67e2da06c01f1640dfbdcc6"
+                "reference": "4fc5e2dd41be3c0b6321e0373072782edeff45ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/710cb7313446aa5ce67e2da06c01f1640dfbdcc6",
-                "reference": "710cb7313446aa5ce67e2da06c01f1640dfbdcc6",
+                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/4fc5e2dd41be3c0b6321e0373072782edeff45ed",
+                "reference": "4fc5e2dd41be3c0b6321e0373072782edeff45ed",
                 "shasum": ""
             },
             "require": {
@@ -3278,7 +3278,7 @@
             "description": "Provides integration for Doctrine with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/doctrine-bridge/tree/v7.4.6"
+                "source": "https://github.com/symfony/doctrine-bridge/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -3298,7 +3298,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-17T08:07:48+00:00"
+            "time": "2026-03-05T08:16:50+00:00"
         },
         {
             "name": "symfony/doctrine-messenger",
@@ -3378,16 +3378,16 @@
         },
         {
             "name": "symfony/dotenv",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dotenv.git",
-                "reference": "db374255a1c99511d34d5e009dce5be75d0d9c23"
+                "reference": "7e5529a0b02395cb4614cdf507495a4cef3115c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dotenv/zipball/db374255a1c99511d34d5e009dce5be75d0d9c23",
-                "reference": "db374255a1c99511d34d5e009dce5be75d0d9c23",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/7e5529a0b02395cb4614cdf507495a4cef3115c5",
+                "reference": "7e5529a0b02395cb4614cdf507495a4cef3115c5",
                 "shasum": ""
             },
             "require": {
@@ -3432,7 +3432,7 @@
                 "environment"
             ],
             "support": {
-                "source": "https://github.com/symfony/dotenv/tree/v7.4.6"
+                "source": "https://github.com/symfony/dotenv/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -3452,7 +3452,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-13T11:43:08+00:00"
+            "time": "2026-03-03T07:48:48+00:00"
         },
         {
             "name": "symfony/error-handler",
@@ -3910,16 +3910,16 @@
         },
         {
             "name": "symfony/framework-bundle",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/framework-bundle.git",
-                "reference": "a4022da7530f794aa64cea34b388439afb6323a3"
+                "reference": "c94bc78c85d76af67918404a95d44940f66a7c2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/a4022da7530f794aa64cea34b388439afb6323a3",
-                "reference": "a4022da7530f794aa64cea34b388439afb6323a3",
+                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/c94bc78c85d76af67918404a95d44940f66a7c2f",
+                "reference": "c94bc78c85d76af67918404a95d44940f66a7c2f",
                 "shasum": ""
             },
             "require": {
@@ -4044,7 +4044,7 @@
             "description": "Provides a tight integration between Symfony components and the Symfony full-stack framework",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/framework-bundle/tree/v7.4.6"
+                "source": "https://github.com/symfony/framework-bundle/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -4064,20 +4064,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T16:50:00+00:00"
+            "time": "2026-03-06T15:39:55+00:00"
         },
         {
             "name": "symfony/http-client",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "2bde8afd5ab2fe0b05a9c2d4c3c0e28ceb98a154"
+                "reference": "1010624285470eb60e88ed10035102c75b4ea6af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/2bde8afd5ab2fe0b05a9c2d4c3c0e28ceb98a154",
-                "reference": "2bde8afd5ab2fe0b05a9c2d4c3c0e28ceb98a154",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/1010624285470eb60e88ed10035102c75b4ea6af",
+                "reference": "1010624285470eb60e88ed10035102c75b4ea6af",
                 "shasum": ""
             },
             "require": {
@@ -4145,7 +4145,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v7.4.6"
+                "source": "https://github.com/symfony/http-client/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -4165,7 +4165,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-18T09:46:18+00:00"
+            "time": "2026-03-05T11:16:58+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -4247,16 +4247,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "fd97d5e926e988a363cef56fbbf88c5c528e9065"
+                "reference": "f94b3e7b7dafd40e666f0c9ff2084133bae41e81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/fd97d5e926e988a363cef56fbbf88c5c528e9065",
-                "reference": "fd97d5e926e988a363cef56fbbf88c5c528e9065",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/f94b3e7b7dafd40e666f0c9ff2084133bae41e81",
+                "reference": "f94b3e7b7dafd40e666f0c9ff2084133bae41e81",
                 "shasum": ""
             },
             "require": {
@@ -4305,7 +4305,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.4.6"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -4325,20 +4325,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-21T16:25:55+00:00"
+            "time": "2026-03-06T13:15:18+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "002ac0cf4cd972a7fd0912dcd513a95e8a81ce83"
+                "reference": "3b3fcf386c809be990c922e10e4c620d6367cab1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/002ac0cf4cd972a7fd0912dcd513a95e8a81ce83",
-                "reference": "002ac0cf4cd972a7fd0912dcd513a95e8a81ce83",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/3b3fcf386c809be990c922e10e4c620d6367cab1",
+                "reference": "3b3fcf386c809be990c922e10e4c620d6367cab1",
                 "shasum": ""
             },
             "require": {
@@ -4424,7 +4424,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.4.6"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -4444,7 +4444,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-26T08:30:57+00:00"
+            "time": "2026-03-06T16:33:18+00:00"
         },
         {
             "name": "symfony/lock",
@@ -4697,16 +4697,16 @@
         },
         {
             "name": "symfony/messenger",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/messenger.git",
-                "reference": "9da6166eb98937d903ed3685b317b426c82d3496"
+                "reference": "13a00f01a46ba7d47ac7f0e3d9a901d19f9432f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/messenger/zipball/9da6166eb98937d903ed3685b317b426c82d3496",
-                "reference": "9da6166eb98937d903ed3685b317b426c82d3496",
+                "url": "https://api.github.com/repos/symfony/messenger/zipball/13a00f01a46ba7d47ac7f0e3d9a901d19f9432f0",
+                "reference": "13a00f01a46ba7d47ac7f0e3d9a901d19f9432f0",
                 "shasum": ""
             },
             "require": {
@@ -4767,7 +4767,7 @@
             "description": "Helps applications send and receive messages to/from other applications or via message queues",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/messenger/tree/v7.4.6"
+                "source": "https://github.com/symfony/messenger/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -4787,7 +4787,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T16:50:00+00:00"
+            "time": "2026-03-04T13:54:41+00:00"
         },
         {
             "name": "symfony/monolog-bridge",
@@ -5843,23 +5843,23 @@
         },
         {
             "name": "symfony/property-info",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-info.git",
-                "reference": "6396b28f44d7c28b209a1bd73acf0dd985a0a4ef"
+                "reference": "02501d75fd834345da3ecdd8e3200ced39e370f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-info/zipball/6396b28f44d7c28b209a1bd73acf0dd985a0a4ef",
-                "reference": "6396b28f44d7c28b209a1bd73acf0dd985a0a4ef",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/02501d75fd834345da3ecdd8e3200ced39e370f8",
+                "reference": "02501d75fd834345da3ecdd8e3200ced39e370f8",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/string": "^6.4|^7.0|^8.0",
-                "symfony/type-info": "~7.3.10|^7.4.4|^8.0.4"
+                "symfony/type-info": "^7.4.7|^8.0.7"
             },
             "conflict": {
                 "phpdocumentor/reflection-docblock": "<5.2|>=7",
@@ -5909,7 +5909,7 @@
                 "validator"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-info/tree/v7.4.6"
+                "source": "https://github.com/symfony/property-info/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -5929,20 +5929,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-13T11:51:31+00:00"
+            "time": "2026-03-04T15:53:26+00:00"
         },
         {
             "name": "symfony/rate-limiter",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/rate-limiter.git",
-                "reference": "7219be81396041c24c1d12241ca7ef1f88b80783"
+                "reference": "c2ff01c8d5ed54f0721f046fde14a94f2df09666"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/rate-limiter/zipball/7219be81396041c24c1d12241ca7ef1f88b80783",
-                "reference": "7219be81396041c24c1d12241ca7ef1f88b80783",
+                "url": "https://api.github.com/repos/symfony/rate-limiter/zipball/c2ff01c8d5ed54f0721f046fde14a94f2df09666",
+                "reference": "c2ff01c8d5ed54f0721f046fde14a94f2df09666",
                 "shasum": ""
             },
             "require": {
@@ -5983,7 +5983,7 @@
                 "rate-limiter"
             ],
             "support": {
-                "source": "https://github.com/symfony/rate-limiter/tree/v7.4.6"
+                "source": "https://github.com/symfony/rate-limiter/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -6003,7 +6003,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T16:50:00+00:00"
+            "time": "2026-03-04T13:54:41+00:00"
         },
         {
             "name": "symfony/routing",
@@ -6544,16 +6544,16 @@
         },
         {
             "name": "symfony/serializer",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "83c3cbd6dcb96c1dbe197499a0714f8dceb0f274"
+                "reference": "bd395bbc6fabd136a48e1a6f91b09f88b5050b0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/83c3cbd6dcb96c1dbe197499a0714f8dceb0f274",
-                "reference": "83c3cbd6dcb96c1dbe197499a0714f8dceb0f274",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/bd395bbc6fabd136a48e1a6f91b09f88b5050b0b",
+                "reference": "bd395bbc6fabd136a48e1a6f91b09f88b5050b0b",
                 "shasum": ""
             },
             "require": {
@@ -6624,7 +6624,7 @@
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v7.4.6"
+                "source": "https://github.com/symfony/serializer/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -6644,7 +6644,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T16:50:00+00:00"
+            "time": "2026-03-06T13:15:18+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -6974,16 +6974,16 @@
         },
         {
             "name": "symfony/twig-bridge",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bridge.git",
-                "reference": "8903bc9a64cf624ffe522893f3626d5a0b97175c"
+                "reference": "c67219ca6b79a57b64e36bbb2cd8ba741286587e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/8903bc9a64cf624ffe522893f3626d5a0b97175c",
-                "reference": "8903bc9a64cf624ffe522893f3626d5a0b97175c",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/c67219ca6b79a57b64e36bbb2cd8ba741286587e",
+                "reference": "c67219ca6b79a57b64e36bbb2cd8ba741286587e",
                 "shasum": ""
             },
             "require": {
@@ -7065,7 +7065,7 @@
             "description": "Provides integration for Twig with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/twig-bridge/tree/v7.4.6"
+                "source": "https://github.com/symfony/twig-bridge/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -7085,7 +7085,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T16:50:00+00:00"
+            "time": "2026-03-04T15:37:05+00:00"
         },
         {
             "name": "symfony/twig-bundle",
@@ -7179,16 +7179,16 @@
         },
         {
             "name": "symfony/type-info",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/type-info.git",
-                "reference": "4855ceea609b2c09e48ff76e12a97a3955531735"
+                "reference": "31f1e40cbf7851c7354281c90eb1b352c4cb8269"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/type-info/zipball/4855ceea609b2c09e48ff76e12a97a3955531735",
-                "reference": "4855ceea609b2c09e48ff76e12a97a3955531735",
+                "url": "https://api.github.com/repos/symfony/type-info/zipball/31f1e40cbf7851c7354281c90eb1b352c4cb8269",
+                "reference": "31f1e40cbf7851c7354281c90eb1b352c4cb8269",
                 "shasum": ""
             },
             "require": {
@@ -7238,7 +7238,7 @@
                 "type"
             ],
             "support": {
-                "source": "https://github.com/symfony/type-info/tree/v7.4.6"
+                "source": "https://github.com/symfony/type-info/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -7258,7 +7258,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-17T14:00:31+00:00"
+            "time": "2026-03-04T12:49:16+00:00"
         },
         {
             "name": "symfony/uid",

--- a/config/packages/mailer.yaml
+++ b/config/packages/mailer.yaml
@@ -1,0 +1,3 @@
+framework:
+    mailer:
+        dsn: '%env(MAILER_DSN)%'

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -15,7 +15,26 @@ framework:
                         default_publish_routing_key: likes
                     queues:
                         likes:
-                            binding_keys: ['likes']
+                            binding_keys: [ 'likes' ]
+                            arguments:
+                                x-dead-letter-exchange: twitter_dlx
+                                x-dead-letter-routing-key: failed
+
+            async_emails:
+                dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
+                retry_strategy:
+                    max_retries: 3
+                    delay: 1000
+                    multiplier: 2
+                    max_delay: 10000
+                options:
+                    exchange:
+                        name: twitter
+                        type: direct
+                        default_publish_routing_key: emails
+                    queues:
+                        emails:
+                            binding_keys: [ 'emails' ]
                             arguments:
                                 x-dead-letter-exchange: twitter_dlx
                                 x-dead-letter-routing-key: failed
@@ -29,16 +48,18 @@ framework:
                         default_publish_routing_key: failed
                     queues:
                         failed:
-                            binding_keys: ['failed']
+                            binding_keys: [ 'failed' ]
 
         failure_transport: failed
 
         routing:
             'Twitter\Tweet\Application\Message\UpdateTweetLikesCountMessage': async
+            'Twitter\Registration\Application\Message\SendWelcomeEmailMessage': async_emails
 
 when@test:
     framework:
         messenger:
             transports:
                 async: 'in-memory://'
+                async_emails: 'in-memory://'
                 failed: 'in-memory://'

--- a/config/reference.php
+++ b/config/reference.php
@@ -576,7 +576,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         }>,
  *     },
  *     mailer?: bool|array{ // Mailer configuration
- *         enabled?: bool|Param, // Default: false
+ *         enabled?: bool|Param, // Default: true
  *         message_bus?: scalar|Param|null, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
  *         dsn?: scalar|Param|null, // Default: null
  *         transports?: array<string, scalar|Param|null>,

--- a/config/reference.php
+++ b/config/reference.php
@@ -1514,8 +1514,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type MercureConfig = array{
  *     hubs?: array<string, array{ // Default: []
- *         url?: scalar|Param|null, // URL of the hub's publish endpoint
- *         public_url?: scalar|Param|null, // URL of the hub's public endpoint // Default: null
+ *         url?: scalar|Param|null, // URL of the hub's publish endpoint // Default: null
+ *         public_url?: scalar|Param|null, // URL of the hub's public endpoint
  *         jwt?: string|array{ // JSON Web Token configuration.
  *             value?: scalar|Param|null, // JSON Web Token to use to publish to this hub.
  *             provider?: scalar|Param|null, // The ID of a service to call to provide the JSON Web Token.

--- a/config/reference.php
+++ b/config/reference.php
@@ -1514,8 +1514,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type MercureConfig = array{
  *     hubs?: array<string, array{ // Default: []
- *         url?: scalar|Param|null, // URL of the hub's publish endpoint // Default: null
- *         public_url?: scalar|Param|null, // URL of the hub's public endpoint
+ *         url?: scalar|Param|null, // URL of the hub's publish endpoint
+ *         public_url?: scalar|Param|null, // URL of the hub's public endpoint // Default: null
  *         jwt?: string|array{ // JSON Web Token configuration.
  *             value?: scalar|Param|null, // JSON Web Token to use to publish to this hub.
  *             provider?: scalar|Param|null, // The ID of a service to call to provide the JSON Web Token.

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -41,6 +41,7 @@ services:
     Twitter\Registration\Application\Message\SendWelcomeEmailHandler:
         arguments:
             $senderAddress: '%env(MAILER_SENDER)%'
+            $appBaseUrl: '%env(DEFAULT_URI)%'
 
     Twitter\IAM\Application\Logout\LogoutHandler:
         arguments:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -36,6 +36,11 @@ services:
     Twitter\Registration\Application\UseCase\RegisterUser\RegisterUserCommandHandler:
         arguments:
             $entityManager: '@doctrine.orm.entity_manager'
+            $messageBus: '@messenger.default_bus'
+
+    Twitter\Registration\Application\Message\SendWelcomeEmailHandler:
+        arguments:
+            $senderAddress: '%env(MAILER_SENDER)%'
 
     Twitter\IAM\Application\Logout\LogoutHandler:
         arguments:
@@ -131,7 +136,7 @@ services:
 
     Twitter\Tweet\Application\EventSubscriber\LikeMessageBridgeSubscriber:
         tags: [ 'kernel.event_subscriber' ]
-        
+    
     Twitter\Tweet\Application\UseCase\GetUserTweets\GetUserTweetsQueryHandlerInterface: '@Twitter\Tweet\Application\UseCase\GetUserTweets\GetUserTweetsQueryHandler'
 
     Twitter\Tweet\Application\Message\UpdateTweetLikesCountHandler: ~

--- a/src/Registration/Application/Message/SendWelcomeEmailHandler.php
+++ b/src/Registration/Application/Message/SendWelcomeEmailHandler.php
@@ -15,6 +15,7 @@ final readonly class SendWelcomeEmailHandler
     public function __construct(
         private MailerInterface $mailer,
         private string $senderAddress,
+        private string $appBaseUrl,
     ) {}
 
     /**
@@ -29,6 +30,7 @@ final readonly class SendWelcomeEmailHandler
             ->htmlTemplate('email/welcome.html.twig')
             ->context([
                 'name' => $message->name,
+                'appBaseUrl' => $this->appBaseUrl,
             ]);
 
         $this->mailer->send($email);

--- a/src/Registration/Application/Message/SendWelcomeEmailHandler.php
+++ b/src/Registration/Application/Message/SendWelcomeEmailHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Registration\Application\Message;
+
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final readonly class SendWelcomeEmailHandler
+{
+    public function __construct(
+        private MailerInterface $mailer,
+        private string $senderAddress,
+    ) {}
+
+    /**
+     * @throws TransportExceptionInterface
+     */
+    public function __invoke(SendWelcomeEmailMessage $message): void
+    {
+        $email = new TemplatedEmail()
+            ->from($this->senderAddress)
+            ->to($message->email)
+            ->subject('Welcome to Twitter!')
+            ->htmlTemplate('email/welcome.html.twig')
+            ->context([
+                'name' => $message->name,
+            ]);
+
+        $this->mailer->send($email);
+    }
+}

--- a/src/Registration/Application/Message/SendWelcomeEmailMessage.php
+++ b/src/Registration/Application/Message/SendWelcomeEmailMessage.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Registration\Application\Message;
+
+final readonly class SendWelcomeEmailMessage
+{
+    public function __construct(
+        public string $email,
+        public string $name,
+    ) {}
+}

--- a/src/Registration/Application/UseCase/RegisterUser/RegisterUserCommandHandler.php
+++ b/src/Registration/Application/UseCase/RegisterUser/RegisterUserCommandHandler.php
@@ -4,31 +4,46 @@ declare(strict_types=1);
 
 namespace Twitter\Registration\Application\UseCase\RegisterUser;
 
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\Exception\ExceptionInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Throwable;
+use Twitter\IAM\Domain\User\Exception\InvalidEmailException;
+use Twitter\IAM\Domain\User\Exception\InvalidPasswordException;
 use Twitter\IAM\Domain\User\Exception\UserAlreadyExistsException;
 use Twitter\IAM\Domain\User\Model\Email;
 use Twitter\IAM\Domain\User\Model\PasswordHash;
 use Twitter\IAM\Domain\User\Model\User;
 use Twitter\Profile\Domain\Profile\Exception\UserNotFoundException;
 use Twitter\Profile\Domain\Profile\Model\Profile;
+use Twitter\Registration\Application\Message\SendWelcomeEmailMessage;
 
 final readonly class RegisterUserCommandHandler
 {
     public function __construct(
         private EntityManagerInterface $entityManager,
+        private MessageBusInterface $messageBus,
     ) {}
 
+    /**
+     * @throws UserNotFoundException
+     * @throws InvalidPasswordException
+     * @throws UserAlreadyExistsException
+     * @throws Throwable
+     * @throws InvalidEmailException
+     * @throws ExceptionInterface
+     * @throws Exception
+     */
     public function handle(RegisterUserCommand $command): RegisterUserCommandResult
     {
         $email = Email::fromString($command->email);
         $passwordHash = PasswordHash::fromPlainPassword($command->password);
+        $user = User::create($email, $passwordHash);
 
         try {
-            $user = User::create($email, $passwordHash);
-            $userId = $user->id();
             $profile = Profile::create(
                 userId: $user->id(),
                 name: $command->name,
@@ -49,12 +64,14 @@ final readonly class RegisterUserCommandHandler
                 throw $e;
             }
 
-            return new RegisterUserCommandResult($userId);
+            $this->messageBus->dispatch(new SendWelcomeEmailMessage($command->email, $command->name));
+
+            return new RegisterUserCommandResult($user->id());
         } catch (UniqueConstraintViolationException) {
             throw new UserAlreadyExistsException((string) $email);
         } catch (ForeignKeyConstraintViolationException) {
             // Should be impossible for fresh registration, but keep consistent error mapping.
-            throw new UserNotFoundException($userId);
+            throw new UserNotFoundException($user->id());
         }
     }
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -181,6 +181,18 @@
             "config/packages/lock.yaml"
         ]
     },
+    "symfony/mailer": {
+        "version": "7.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "4.3",
+            "ref": "09051cfde49476e3c12cd3a0e44289ace1c75a4f"
+        },
+        "files": [
+            "config/packages/mailer.yaml"
+        ]
+    },
     "symfony/mercure-bundle": {
         "version": "0.4",
         "recipe": {

--- a/templates/email/welcome.html.twig
+++ b/templates/email/welcome.html.twig
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Welcome to Twitter!</title>
+    </head>
+    <body style="margin:0;padding:0;background-color:#f5f8fa;font-family:Arial,Helvetica,sans-serif;color:#14171a;">
+        <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f5f8fa;padding:40px 0;">
+            <tr>
+                <td align="center">
+                    <table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:8px;overflow:hidden;max-width:600px;width:100%;">
+
+                        <tr>
+                            <td style="background-color:#1da1f2;padding:32px 40px;">
+                                <h1 style="margin:0;color:#ffffff;font-size:24px;font-weight:700;letter-spacing:-0.5px;">Twitter</h1>
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td style="padding:40px;">
+                                <h2 style="margin:0 0 16px;font-size:22px;font-weight:700;color:#14171a;">Welcome, {{ name }}!</h2>
+                                <p style="margin:0 0 32px;font-size:16px;line-height:1.6;color:#657786;">
+                                    Your account is ready. Here are a few things you can do to get started:
+                                </p>
+
+                                <table width="100%" cellpadding="0" cellspacing="0">
+                                    <tr>
+                                        <td style="padding:16px;background-color:#f5f8fa;border-radius:6px;margin-bottom:12px;">
+                                            <p style="margin:0;font-size:15px;font-weight:700;color:#14171a;">&#128240; Browse the feed</p>
+                                            <p style="margin:4px 0 0;font-size:14px;color:#657786;">See what others are tweeting about right now.</p>
+                                        </td>
+                                    </tr>
+                                    <tr><td style="height:12px;"></td></tr>
+                                    <tr>
+                                        <td style="padding:16px;background-color:#f5f8fa;border-radius:6px;">
+                                            <p style="margin:0;font-size:15px;font-weight:700;color:#14171a;">&#10084;&#65039; Like a tweet</p>
+                                            <p style="margin:4px 0 0;font-size:14px;color:#657786;">Show some love to posts that resonate with you.</p>
+                                        </td>
+                                    </tr>
+                                    <tr><td style="height:12px;"></td></tr>
+                                    <tr>
+                                        <td style="padding:16px;background-color:#f5f8fa;border-radius:6px;">
+                                            <p style="margin:0;font-size:15px;font-weight:700;color:#14171a;">&#9999;&#65039; Write your first tweet</p>
+                                            <p style="margin:4px 0 0;font-size:14px;color:#657786;">Share a thought, an idea, or anything on your mind.</p>
+                                        </td>
+                                    </tr>
+                                </table>
+
+                                <table width="100%" cellpadding="0" cellspacing="0" style="margin-top:32px;">
+                                    <tr>
+                                        <td align="center">
+                                            <a href="{{ app.request is not null ? app.request.schemeAndHttpHost : '' }}/"
+                                               style="display:inline-block;background-color:#1da1f2;color:#ffffff;text-decoration:none;font-size:15px;font-weight:700;padding:14px 32px;border-radius:24px;">
+                                                Go to your feed
+                                            </a>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td style="padding:24px 40px;border-top:1px solid #e1e8ed;">
+                                <p style="margin:0;font-size:12px;color:#aab8c2;text-align:center;">
+                                    You received this email because you created an account on Twitter.<br>
+                                    If you did not sign up, you can safely ignore this message.
+                                </p>
+                            </td>
+                        </tr>
+
+                    </table>
+                </td>
+            </tr>
+        </table>
+    </body>
+</html>

--- a/templates/email/welcome.html.twig
+++ b/templates/email/welcome.html.twig
@@ -1,77 +1,90 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Welcome to Twitter!</title>
-    </head>
-    <body style="margin:0;padding:0;background-color:#f5f8fa;font-family:Arial,Helvetica,sans-serif;color:#14171a;">
-        <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f5f8fa;padding:40px 0;">
-            <tr>
-                <td align="center">
-                    <table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:8px;overflow:hidden;max-width:600px;width:100%;">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Welcome to Twitter!</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f5f8fa;font-family:Arial,Helvetica,sans-serif;color:#14171a;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f5f8fa;padding:40px 0;">
+    <tr>
+        <td align="center">
+            <table width="600" cellpadding="0" cellspacing="0"
+                   style="background-color:#ffffff;border-radius:8px;overflow:hidden;max-width:600px;width:100%;">
 
-                        <tr>
-                            <td style="background-color:#1da1f2;padding:32px 40px;">
-                                <h1 style="margin:0;color:#ffffff;font-size:24px;font-weight:700;letter-spacing:-0.5px;">Twitter</h1>
-                            </td>
-                        </tr>
+                <tr>
+                    <td style="background-color:#1da1f2;padding:32px 40px;">
+                        <h1 style="margin:0;color:#ffffff;font-size:24px;font-weight:700;letter-spacing:-0.5px;">
+                            Twitter</h1>
+                    </td>
+                </tr>
 
-                        <tr>
-                            <td style="padding:40px;">
-                                <h2 style="margin:0 0 16px;font-size:22px;font-weight:700;color:#14171a;">Welcome, {{ name }}!</h2>
-                                <p style="margin:0 0 32px;font-size:16px;line-height:1.6;color:#657786;">
-                                    Your account is ready. Here are a few things you can do to get started:
-                                </p>
+                <tr>
+                    <td style="padding:40px;">
+                        <h2 style="margin:0 0 16px;font-size:22px;font-weight:700;color:#14171a;">Welcome, {{ name }}
+                            !</h2>
+                        <p style="margin:0 0 32px;font-size:16px;line-height:1.6;color:#657786;">
+                            Your account is ready. Here are a few things you can do to get started:
+                        </p>
 
-                                <table width="100%" cellpadding="0" cellspacing="0">
-                                    <tr>
-                                        <td style="padding:16px;background-color:#f5f8fa;border-radius:6px;margin-bottom:12px;">
-                                            <p style="margin:0;font-size:15px;font-weight:700;color:#14171a;">&#128240; Browse the feed</p>
-                                            <p style="margin:4px 0 0;font-size:14px;color:#657786;">See what others are tweeting about right now.</p>
-                                        </td>
-                                    </tr>
-                                    <tr><td style="height:12px;"></td></tr>
-                                    <tr>
-                                        <td style="padding:16px;background-color:#f5f8fa;border-radius:6px;">
-                                            <p style="margin:0;font-size:15px;font-weight:700;color:#14171a;">&#10084;&#65039; Like a tweet</p>
-                                            <p style="margin:4px 0 0;font-size:14px;color:#657786;">Show some love to posts that resonate with you.</p>
-                                        </td>
-                                    </tr>
-                                    <tr><td style="height:12px;"></td></tr>
-                                    <tr>
-                                        <td style="padding:16px;background-color:#f5f8fa;border-radius:6px;">
-                                            <p style="margin:0;font-size:15px;font-weight:700;color:#14171a;">&#9999;&#65039; Write your first tweet</p>
-                                            <p style="margin:4px 0 0;font-size:14px;color:#657786;">Share a thought, an idea, or anything on your mind.</p>
-                                        </td>
-                                    </tr>
-                                </table>
+                        <table width="100%" cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td style="padding:16px;background-color:#f5f8fa;border-radius:6px;margin-bottom:12px;">
+                                    <p style="margin:0;font-size:15px;font-weight:700;color:#14171a;">&#128240; Browse
+                                        the feed</p>
+                                    <p style="margin:4px 0 0;font-size:14px;color:#657786;">See what others are tweeting
+                                        about right now.</p>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style="height:12px;"></td>
+                            </tr>
+                            <tr>
+                                <td style="padding:16px;background-color:#f5f8fa;border-radius:6px;">
+                                    <p style="margin:0;font-size:15px;font-weight:700;color:#14171a;">&#10084;&#65039;
+                                        Like a tweet</p>
+                                    <p style="margin:4px 0 0;font-size:14px;color:#657786;">Show some love to posts that
+                                        resonate with you.</p>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style="height:12px;"></td>
+                            </tr>
+                            <tr>
+                                <td style="padding:16px;background-color:#f5f8fa;border-radius:6px;">
+                                    <p style="margin:0;font-size:15px;font-weight:700;color:#14171a;">&#9999;&#65039;
+                                        Write your first tweet</p>
+                                    <p style="margin:4px 0 0;font-size:14px;color:#657786;">Share a thought, an idea, or
+                                        anything on your mind.</p>
+                                </td>
+                            </tr>
+                        </table>
 
-                                <table width="100%" cellpadding="0" cellspacing="0" style="margin-top:32px;">
-                                    <tr>
-                                        <td align="center">
-                                            <a href="{{ app.request is not null ? app.request.schemeAndHttpHost : '' }}/"
-                                               style="display:inline-block;background-color:#1da1f2;color:#ffffff;text-decoration:none;font-size:15px;font-weight:700;padding:14px 32px;border-radius:24px;">
-                                                Go to your feed
-                                            </a>
-                                        </td>
-                                    </tr>
-                                </table>
-                            </td>
-                        </tr>
+                        <table width="100%" cellpadding="0" cellspacing="0" style="margin-top:32px;">
+                            <tr>
+                                <td align="center">
+                                    <a href="{{ appBaseUrl }}/"
+                                       style="display:inline-block;background-color:#1da1f2;color:#ffffff;text-decoration:none;font-size:15px;font-weight:700;padding:14px 32px;border-radius:24px;">
+                                        Go to your feed
+                                    </a>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
 
-                        <tr>
-                            <td style="padding:24px 40px;border-top:1px solid #e1e8ed;">
-                                <p style="margin:0;font-size:12px;color:#aab8c2;text-align:center;">
-                                    You received this email because you created an account on Twitter.<br>
-                                    If you did not sign up, you can safely ignore this message.
-                                </p>
-                            </td>
-                        </tr>
+                <tr>
+                    <td style="padding:24px 40px;border-top:1px solid #e1e8ed;">
+                        <p style="margin:0;font-size:12px;color:#aab8c2;text-align:center;">
+                            You received this email because you created an account on Twitter.<br>
+                            If you did not sign up, you can safely ignore this message.
+                        </p>
+                    </td>
+                </tr>
 
-                    </table>
-                </td>
-            </tr>
-        </table>
-    </body>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
 </html>

--- a/templates/email/welcome.html.twig
+++ b/templates/email/welcome.html.twig
@@ -21,8 +21,7 @@
 
                 <tr>
                     <td style="padding:40px;">
-                        <h2 style="margin:0 0 16px;font-size:22px;font-weight:700;color:#14171a;">Welcome, {{ name }}
-                            !</h2>
+                        <h2 style="margin:0 0 16px;font-size:22px;font-weight:700;color:#14171a;">Welcome, {{ name }}!</h2>
                         <p style="margin:0 0 32px;font-size:16px;line-height:1.6;color:#657786;">
                             Your account is ready. Here are a few things you can do to get started:
                         </p>

--- a/tests/Registration/Application/Message/SendWelcomeEmailHandlerTest.php
+++ b/tests/Registration/Application/Message/SendWelcomeEmailHandlerTest.php
@@ -30,6 +30,7 @@ final class SendWelcomeEmailHandlerTest extends TestCase
         $this->handler = new SendWelcomeEmailHandler(
             mailer: $this->mailer,
             senderAddress: 'noreply@twitter.local',
+            appBaseUrl: 'https://localhost',
         );
     }
 

--- a/tests/Registration/Application/Message/SendWelcomeEmailHandlerTest.php
+++ b/tests/Registration/Application/Message/SendWelcomeEmailHandlerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Tests\Registration\Application\Message;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Twitter\Registration\Application\Message\SendWelcomeEmailHandler;
+use Twitter\Registration\Application\Message\SendWelcomeEmailMessage;
+
+#[Group('unit')]
+#[CoversClass(SendWelcomeEmailHandler::class)]
+final class SendWelcomeEmailHandlerTest extends TestCase
+{
+    private MailerInterface&MockObject $mailer;
+    private SendWelcomeEmailHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->mailer = $this->createMock(MailerInterface::class);
+
+        $this->handler = new SendWelcomeEmailHandler(
+            mailer: $this->mailer,
+            senderAddress: 'noreply@twitter.local',
+        );
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     */
+    #[Test]
+    public function sendsWelcomeEmailToRegisteredUser(): void
+    {
+        $this->mailer
+            ->expects(self::once())
+            ->method('send')
+            ->with(self::callback(
+                static fn (mixed $email): bool => $email instanceof Email
+                    && in_array('jane@example.com', array_map(
+                        static fn (Address $a): string => $a->getAddress(),
+                        $email->getTo(),
+                    ), true)
+                    && 'noreply@twitter.local' === $email->getFrom()[0]->getAddress(),
+            ));
+
+        ($this->handler)(new SendWelcomeEmailMessage(
+            email: 'jane@example.com',
+            name: 'Jane Doe',
+        ));
+    }
+}

--- a/tests/Registration/Application/UseCase/RegisterUser/RegisterUserCommandHandlerTest.php
+++ b/tests/Registration/Application/UseCase/RegisterUser/RegisterUserCommandHandlerTest.php
@@ -6,6 +6,7 @@ namespace Twitter\Tests\Registration\Application\UseCase\RegisterUser;
 
 use Assert\LazyAssertionException;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -15,9 +16,15 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use stdClass;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\ExceptionInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Twitter\IAM\Domain\User\Exception\InvalidEmailException;
 use Twitter\IAM\Domain\User\Exception\InvalidPasswordException;
 use Twitter\IAM\Domain\User\Exception\UserAlreadyExistsException;
+use Twitter\Profile\Domain\Profile\Exception\UserNotFoundException;
+use Twitter\Registration\Application\Message\SendWelcomeEmailMessage;
 use Twitter\Registration\Application\UseCase\RegisterUser\RegisterUserCommand;
 use Twitter\Registration\Application\UseCase\RegisterUser\RegisterUserCommandHandler;
 
@@ -28,14 +35,17 @@ final class RegisterUserCommandHandlerTest extends TestCase
     private RegisterUserCommandHandler $handler;
     private EntityManagerInterface&MockObject $entityManager;
     private Connection&MockObject $connection;
+    private MessageBusInterface&MockObject $messageBus;
 
     protected function setUp(): void
     {
         $this->entityManager = $this->createMock(EntityManagerInterface::class);
         $this->connection = $this->createMock(Connection::class);
+        $this->messageBus = $this->createMock(MessageBusInterface::class);
 
         $this->handler = new RegisterUserCommandHandler(
             $this->entityManager,
+            $this->messageBus,
         );
     }
 
@@ -67,6 +77,16 @@ final class RegisterUserCommandHandlerTest extends TestCase
             ->expects(self::once())
             ->method('flush');
 
+        $this->messageBus
+            ->expects(self::once())
+            ->method('dispatch')
+            ->with(self::callback(
+                static fn (mixed $message): bool => $message instanceof SendWelcomeEmailMessage
+                    && 'test@example.com' === $message->email
+                    && 'John Doe' === $message->name,
+            ))
+            ->willReturn(new Envelope(new stdClass()));
+
         $result = $this->handler->handle(new RegisterUserCommand(
             email: 'test@example.com',
             password: 'Qwerty.123',
@@ -81,6 +101,14 @@ final class RegisterUserCommandHandlerTest extends TestCase
         );
     }
 
+    /**
+     * @throws UserNotFoundException
+     * @throws \Throwable
+     * @throws InvalidPasswordException
+     * @throws UserAlreadyExistsException
+     * @throws Exception
+     * @throws ExceptionInterface
+     */
     #[Test]
     #[AllowMockObjectsWithoutExpectations]
     public function failsWhenEmailIsInvalid(): void
@@ -91,6 +119,10 @@ final class RegisterUserCommandHandlerTest extends TestCase
             ->expects(self::never())
             ->method('getConnection');
 
+        $this->messageBus
+            ->expects(self::never())
+            ->method('dispatch');
+
         $this->handler->handle(new RegisterUserCommand(
             email: 'invalid',
             password: 'Qwerty.123',
@@ -99,6 +131,14 @@ final class RegisterUserCommandHandlerTest extends TestCase
         ));
     }
 
+    /**
+     * @throws UserNotFoundException
+     * @throws \Throwable
+     * @throws InvalidEmailException
+     * @throws Exception
+     * @throws ExceptionInterface
+     * @throws UserAlreadyExistsException
+     */
     #[Test]
     #[AllowMockObjectsWithoutExpectations]
     public function failsWhenPasswordIsInvalid(): void
@@ -109,6 +149,10 @@ final class RegisterUserCommandHandlerTest extends TestCase
             ->expects(self::never())
             ->method('getConnection');
 
+        $this->messageBus
+            ->expects(self::never())
+            ->method('dispatch');
+
         $this->handler->handle(new RegisterUserCommand(
             email: 'test@example.com',
             password: 'invalid',
@@ -117,6 +161,15 @@ final class RegisterUserCommandHandlerTest extends TestCase
         ));
     }
 
+    /**
+     * @throws UserNotFoundException
+     * @throws InvalidPasswordException
+     * @throws UserAlreadyExistsException
+     * @throws \Throwable
+     * @throws InvalidEmailException
+     * @throws Exception
+     * @throws ExceptionInterface
+     */
     #[Test]
     #[AllowMockObjectsWithoutExpectations]
     public function failsWhenProfileNameIsInvalid(): void
@@ -127,6 +180,10 @@ final class RegisterUserCommandHandlerTest extends TestCase
             ->expects(self::never())
             ->method('getConnection');
 
+        $this->messageBus
+            ->expects(self::never())
+            ->method('dispatch');
+
         $this->handler->handle(new RegisterUserCommand(
             email: 'test@example.com',
             password: 'Qwerty.123',
@@ -135,6 +192,14 @@ final class RegisterUserCommandHandlerTest extends TestCase
         ));
     }
 
+    /**
+     * @throws UserNotFoundException
+     * @throws \Throwable
+     * @throws InvalidPasswordException
+     * @throws InvalidEmailException
+     * @throws ExceptionInterface
+     * @throws Exception
+     */
     #[Test]
     #[AllowMockObjectsWithoutExpectations]
     public function rollsBackWhenUserAlreadyExists(): void
@@ -167,6 +232,10 @@ final class RegisterUserCommandHandlerTest extends TestCase
             ->method('flush')
             ->willThrowException($this->createMock(UniqueConstraintViolationException::class));
 
+        $this->messageBus
+            ->expects(self::never())
+            ->method('dispatch');
+
         $this->handler->handle(new RegisterUserCommand(
             email: 'test@example.com',
             password: 'Qwerty.123',
@@ -175,6 +244,15 @@ final class RegisterUserCommandHandlerTest extends TestCase
         ));
     }
 
+    /**
+     * @throws UserNotFoundException
+     * @throws InvalidPasswordException
+     * @throws UserAlreadyExistsException
+     * @throws \Throwable
+     * @throws InvalidEmailException
+     * @throws ExceptionInterface
+     * @throws Exception
+     */
     #[Test]
     #[AllowMockObjectsWithoutExpectations]
     public function propagatesUnexpectedFailuresAndRollsBack(): void
@@ -206,6 +284,10 @@ final class RegisterUserCommandHandlerTest extends TestCase
             ->expects(self::once())
             ->method('flush')
             ->willThrowException(new RuntimeException());
+
+        $this->messageBus
+            ->expects(self::never())
+            ->method('dispatch');
 
         $this->handler->handle(new RegisterUserCommand(
             email: 'test@example.com',

--- a/tests/Registration/Application/UseCase/RegisterUser/RegisterUserCommandHandlerTest.php
+++ b/tests/Registration/Application/UseCase/RegisterUser/RegisterUserCommandHandlerTest.php
@@ -20,6 +20,7 @@ use stdClass;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\ExceptionInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Throwable;
 use Twitter\IAM\Domain\User\Exception\InvalidEmailException;
 use Twitter\IAM\Domain\User\Exception\InvalidPasswordException;
 use Twitter\IAM\Domain\User\Exception\UserAlreadyExistsException;
@@ -103,7 +104,7 @@ final class RegisterUserCommandHandlerTest extends TestCase
 
     /**
      * @throws UserNotFoundException
-     * @throws \Throwable
+     * @throws Throwable
      * @throws InvalidPasswordException
      * @throws UserAlreadyExistsException
      * @throws Exception
@@ -133,7 +134,7 @@ final class RegisterUserCommandHandlerTest extends TestCase
 
     /**
      * @throws UserNotFoundException
-     * @throws \Throwable
+     * @throws Throwable
      * @throws InvalidEmailException
      * @throws Exception
      * @throws ExceptionInterface
@@ -165,7 +166,7 @@ final class RegisterUserCommandHandlerTest extends TestCase
      * @throws UserNotFoundException
      * @throws InvalidPasswordException
      * @throws UserAlreadyExistsException
-     * @throws \Throwable
+     * @throws Throwable
      * @throws InvalidEmailException
      * @throws Exception
      * @throws ExceptionInterface
@@ -194,7 +195,7 @@ final class RegisterUserCommandHandlerTest extends TestCase
 
     /**
      * @throws UserNotFoundException
-     * @throws \Throwable
+     * @throws Throwable
      * @throws InvalidPasswordException
      * @throws InvalidEmailException
      * @throws ExceptionInterface
@@ -248,7 +249,7 @@ final class RegisterUserCommandHandlerTest extends TestCase
      * @throws UserNotFoundException
      * @throws InvalidPasswordException
      * @throws UserAlreadyExistsException
-     * @throws \Throwable
+     * @throws Throwable
      * @throws InvalidEmailException
      * @throws ExceptionInterface
      * @throws Exception


### PR DESCRIPTION
**Jira**: [SCRUM-112](https://epam-team-php.atlassian.net/browse/SCRUM-112)

## Description

Send an email to the user on successful registration.

The welcome email template uses HTML table attributes (`width`, `cellpadding`, `cellspacing`, `align`) that are marked as obsolete in the HTML5 spec. These are intentionally kept because email clients — particularly Outlook, Gmail, and Yahoo Mail — have limited and inconsistent CSS support. HTML table attributes remain the most reliable way to control layout across email clients and are the industry standard recommended by every major email framework (MJML, Foundation for Emails, Maizzle). The IDE warnings for these attributes are false positives in the context of email HTML.

## How to roll back?

Revert this pull request.

## How has this been tested?

Email sending handler is covered by unit tests.

## Media attachments

Live presentation:

https://github.com/user-attachments/assets/c1f74f8e-5040-462b-aa9d-b7de5fb553fe

### Email template look on different devices

On a fullscreen display:

<img width="1897" height="811" alt="Screenshot 2026-03-09 130239" src="https://github.com/user-attachments/assets/4ee6eca6-f92e-4712-adae-b30ad828552a" />

On a tablet:

<img width="806" height="1171" alt="Screenshot 2026-03-09 130223" src="https://github.com/user-attachments/assets/d082db21-9d16-42cc-afb3-9cb9915df38d" />

On a smartphone:

<img width="360" height="713" alt="Screenshot 2026-03-09 130210" src="https://github.com/user-attachments/assets/e66e113c-68c9-4f1b-bfa3-11094e3f3f0a" />