### PR TITLE
feat(cache): SCRUM-116 Implement Caching Proxies for Main and User Feeds

### DIFF
--- a/.env
+++ b/.env
@@ -62,7 +62,7 @@ MESSENGER_TRANSPORT_DSN=amqp://app:app@rabbitmq:5672/%2f/messages
 ###< symfony/messenger ###
 
 ###> Redis & Caching Infrastructure ###
-REDIS_URL=redis://redis:6379
+REDIS_URL=redis://redis:6379?persistent=1
 CACHE_TTL_FEED_MAIN=60
 CACHE_TTL_FEED_USER=600
 CACHE_TTL_PROFILE=3600

--- a/.env.test
+++ b/.env.test
@@ -3,7 +3,7 @@ KERNEL_CLASS='App\Kernel'
 APP_SECRET='$ecretf0rt3st'
 
 ###> Redis & Caching Infrastructure ###
-REDIS_URL=redis://redis:6379/1
+REDIS_URL=redis://redis:6379/1?persistent=1
 CACHE_TTL_FEED_MAIN=60
 CACHE_TTL_FEED_USER=600
 CACHE_TTL_PROFILE=3600

--- a/config/packages/cache.yaml
+++ b/config/packages/cache.yaml
@@ -7,9 +7,9 @@ framework:
 
         pools:
             cache.tweets:
-                adapter: cache.adapter.redis
+                adapter: cache.adapter.redis_tag_aware
                 tags: true
 
             cache.profiles:
-                adapter: cache.adapter.redis
+                adapter: cache.adapter.redis_tag_aware
                 tags: true

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -145,6 +145,13 @@ services:
             $cacheTweets: '@cache.tweets'
             $ttl: '%cache_ttl_feed_main%'
 
+    Twitter\Tweet\Infrastructure\Cache\Proxy\GetUserTweetsQueryHandlerProxy:
+        decorates: Twitter\Tweet\Application\UseCase\GetUserTweets\GetUserTweetsQueryHandlerInterface
+        arguments:
+            $inner: '@.inner'
+            $cacheTweets: '@cache.tweets'
+            $ttl: '%cache_ttl_feed_user%'
+
     Twitter\Tweet\Application\Message\UpdateTweetLikesCountHandler: ~
 
     Twitter\Tweet\Infrastructure\Service\TweetLikesCountUpdaterInterface:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -138,6 +138,13 @@ services:
         
     Twitter\Tweet\Application\UseCase\GetUserTweets\GetUserTweetsQueryHandlerInterface: '@Twitter\Tweet\Application\UseCase\GetUserTweets\GetUserTweetsQueryHandler'
 
+    Twitter\Tweet\Infrastructure\Cache\Proxy\GetTweetsCommandHandlerProxy:
+        decorates: Twitter\Tweet\Application\UseCase\GetTweets\GetTweetsCommandHandlerInterface
+        arguments:
+            $inner: '@.inner'
+            $cacheTweets: '@cache.tweets'
+            $ttl: '%cache_ttl_feed_main%'
+
     Twitter\Tweet\Application\Message\UpdateTweetLikesCountHandler: ~
 
     Twitter\Tweet\Infrastructure\Service\TweetLikesCountUpdaterInterface:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,5 +1,9 @@
 # yaml-language-server: $schema=../vendor/symfony/dependency-injection/Loader/schema/services.schema.json
 
+parameters:
+    cache_ttl_feed_main: '%env(int:CACHE_TTL_FEED_MAIN)%'
+    cache_ttl_feed_user: '%env(int:CACHE_TTL_FEED_USER)%'
+
 services:
     _defaults:
         autowire: true

--- a/src/Tweet/Infrastructure/Cache/Proxy/GetTweetsCommandHandlerProxy.php
+++ b/src/Tweet/Infrastructure/Cache/Proxy/GetTweetsCommandHandlerProxy.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Tweet\Infrastructure\Cache\Proxy;
+
+use Override;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use Twitter\Tweet\Application\UseCase\GetTweets\GetTweetsCommand;
+use Twitter\Tweet\Application\UseCase\GetTweets\GetTweetsCommandHandlerInterface;
+use Twitter\Tweet\Application\UseCase\GetTweets\GetTweetsResponse;
+
+final readonly class GetTweetsCommandHandlerProxy implements GetTweetsCommandHandlerInterface
+{
+    public function __construct(
+        private GetTweetsCommandHandlerInterface $inner,
+        private TagAwareCacheInterface $cacheTweets,
+        private int $ttl,
+    ) {}
+
+    #[Override]
+    public function handle(GetTweetsCommand $command): GetTweetsResponse
+    {
+        return $this->cacheTweets->get(
+            sprintf(
+                'tweets_main_limit_%d_page_%d',
+                $command->limit,
+                $command->page,
+            ),
+            function (ItemInterface $item) use ($command): GetTweetsResponse {
+                $item->expiresAfter($this->ttl);
+                $item->tag(['tweets_main']);
+
+                return $this->inner->handle($command);
+            }
+        );
+    }
+}

--- a/src/Tweet/Infrastructure/Cache/Proxy/GetUserTweetsQueryHandlerProxy.php
+++ b/src/Tweet/Infrastructure/Cache/Proxy/GetUserTweetsQueryHandlerProxy.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Tweet\Infrastructure\Cache\Proxy;
+
+use Override;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use Twitter\Tweet\Application\UseCase\GetUserTweets\GetUserTweetsQuery;
+use Twitter\Tweet\Application\UseCase\GetUserTweets\GetUserTweetsQueryHandlerInterface;
+use Twitter\Tweet\Application\UseCase\GetUserTweets\GetUserTweetsQueryResult;
+
+final readonly class GetUserTweetsQueryHandlerProxy implements GetUserTweetsQueryHandlerInterface
+{
+    public function __construct(
+        private GetUserTweetsQueryHandlerInterface $inner,
+        private TagAwareCacheInterface $cacheTweets,
+        private int $ttl,
+    ) {}
+
+    #[Override]
+    public function handle(GetUserTweetsQuery $query): GetUserTweetsQueryResult
+    {
+        return $this->cacheTweets->get(
+            sprintf(
+                'user_tweets_%s_limit_%d_page_%d',
+                $query->userId,
+                $query->limit,
+                $query->page,
+            ),
+            function (ItemInterface $item) use ($query): GetUserTweetsQueryResult {
+                $item->expiresAfter($this->ttl);
+                $item->tag([
+                    'user_tweets',
+                    sprintf('user_tweets_%s', $query->userId),
+                ]);
+
+                return $this->inner->handle($query);
+            }
+        );
+    }
+}

--- a/tests/Tweet/Infrastructure/Cache/Proxy/GetTweetsCommandHandlerProxyTest.php
+++ b/tests/Tweet/Infrastructure/Cache/Proxy/GetTweetsCommandHandlerProxyTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Tests\Tweet\Infrastructure\Cache\Proxy;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+use Twitter\Tweet\Application\UseCase\GetTweets\GetTweetsCommand;
+use Twitter\Tweet\Application\UseCase\GetTweets\GetTweetsCommandHandlerInterface;
+use Twitter\Tweet\Application\UseCase\GetTweets\GetTweetsResponse;
+use Twitter\Tweet\Infrastructure\Cache\Proxy\GetTweetsCommandHandlerProxy;
+
+#[Group('unit')]
+#[CoversClass(GetTweetsCommandHandlerProxy::class)]
+final class GetTweetsCommandHandlerProxyTest extends TestCase
+{
+    private GetTweetsCommandHandlerInterface&MockObject $inner;
+    private TagAwareAdapter $cache;
+    private GetTweetsCommandHandlerProxy $proxy;
+    private int $ttl = 60;
+
+    protected function setUp(): void
+    {
+        $this->inner = $this->createMock(GetTweetsCommandHandlerInterface::class);
+        $this->cache = new TagAwareAdapter(new ArrayAdapter());
+        $this->proxy = new GetTweetsCommandHandlerProxy($this->inner, $this->cache, $this->ttl);
+    }
+
+    #[Test]
+    public function itCachesResultsAndInvalidatesViaTags(): void
+    {
+        $command = new GetTweetsCommand(limit: 50, page: 2);
+        $expectedResponse = new GetTweetsResponse([]);
+
+        // Expected to be called twice: 1st for initial cache miss, 2nd after invalidation
+        $this->inner
+            ->expects(self::exactly(2))
+            ->method('handle')
+            ->with($command)
+            ->willReturn($expectedResponse);
+
+        $result1 = $this->proxy->handle($command);
+        self::assertEquals($expectedResponse, $result1);
+
+        $result2 = $this->proxy->handle($command);
+        self::assertEquals($expectedResponse, $result2);
+
+        $this->cache->invalidateTags(['tweets_main']);
+
+        $result3 = $this->proxy->handle($command);
+        self::assertEquals($expectedResponse, $result3);
+    }
+}

--- a/tests/Tweet/Infrastructure/Cache/Proxy/GetUserTweetsQueryHandlerProxyTest.php
+++ b/tests/Tweet/Infrastructure/Cache/Proxy/GetUserTweetsQueryHandlerProxyTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Tests\Tweet\Infrastructure\Cache\Proxy;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+use Twitter\Tweet\Application\UseCase\GetUserTweets\GetUserTweetsQuery;
+use Twitter\Tweet\Application\UseCase\GetUserTweets\GetUserTweetsQueryHandlerInterface;
+use Twitter\Tweet\Application\UseCase\GetUserTweets\GetUserTweetsQueryResult;
+use Twitter\Tweet\Infrastructure\Cache\Proxy\GetUserTweetsQueryHandlerProxy;
+
+#[Group('unit')]
+#[CoversClass(GetUserTweetsQueryHandlerProxy::class)]
+final class GetUserTweetsQueryHandlerProxyTest extends TestCase
+{
+    private GetUserTweetsQueryHandlerInterface&MockObject $inner;
+    private TagAwareAdapter $cache;
+    private GetUserTweetsQueryHandlerProxy $proxy;
+    private int $ttl = 600;
+
+    protected function setUp(): void
+    {
+        $this->inner = $this->createMock(GetUserTweetsQueryHandlerInterface::class);
+        $this->cache = new TagAwareAdapter(new ArrayAdapter());
+        $this->proxy = new GetUserTweetsQueryHandlerProxy($this->inner, $this->cache, $this->ttl);
+    }
+
+    #[Test]
+    public function itCachesResultsAndInvalidatesViaSpecificUserTag(): void
+    {
+        $userId = '019b5f3f-d110-7908-9177-5df439942a8b';
+        $query = new GetUserTweetsQuery(userId: $userId, limit: 10, page: 1);
+        $expectedResult = new GetUserTweetsQueryResult([]);
+
+        // Expected to be called twice: 1st for miss, 2nd after invalidation
+        $this->inner
+            ->expects(self::exactly(2))
+            ->method('handle')
+            ->with($query)
+            ->willReturn($expectedResult);
+
+        $result1 = $this->proxy->handle($query);
+        self::assertEquals($expectedResult, $result1);
+
+        $result2 = $this->proxy->handle($query);
+        self::assertEquals($expectedResult, $result2);
+
+        $this->cache->invalidateTags([sprintf('user_tweets_%s', $userId)]);
+
+        $result3 = $this->proxy->handle($query);
+        self::assertEquals($expectedResult, $result3);
+    }
+
+    #[Test]
+    public function itInvalidatesViaGeneralUserTweetsTag(): void
+    {
+        $userId = '019b5f3f-d110-7908-9177-5df439942a8b';
+        $query = new GetUserTweetsQuery(userId: $userId, limit: 10, page: 1);
+        $expectedResult = new GetUserTweetsQueryResult([]);
+
+        $this->inner
+            ->expects(self::exactly(2))
+            ->method('handle')
+            ->willReturn($expectedResult);
+
+        $this->proxy->handle($query);
+        $this->proxy->handle($query);
+
+        $this->cache->invalidateTags(['user_tweets']);
+
+        $this->proxy->handle($query);
+    }
+}


### PR DESCRIPTION
**Jira**: [SCRUM-116](https://epam-team-php.atlassian.net/browse/SCRUM-116)

## Description

Implement caching for the Main Feed and User Feed using the Proxy pattern.

## How to roll back?

Revert this pull request.

## How has this been tested?

```
$ docker compose exec php ./vendor/bin/phpunit tests/Tweet/Infrastructure/Cache/Proxy --display-all-issues --testdox --group unit

PHPUnit 12.5.14 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.18
Configuration: /app/phpunit.dist.xml

...                                                                 3 / 3 (100%)

Time: 00:00.016, Memory: 16.00 MB

Get Tweets Command Handler Proxy (Twitter\Tests\Tweet\Infrastructure\Cache\Proxy\GetTweetsCommandHandlerProxy)
 ✔ It caches results and invalidates via tags

Get User Tweets Query Handler Proxy (Twitter\Tests\Tweet\Infrastructure\Cache\Proxy\GetUserTweetsQueryHandlerProxy)
 ✔ It caches results and invalidates via specific user tag
 ✔ It invalidates via general user tweets tag

OK (3 tests, 13 assertions)
```

## Media attachments (optional)

### Main Feed

1. Initial Call (Cache Miss):

  <img width="1732" height="992" alt="Screenshot 2026-03-09 at 14-00-11 Symfony Profiler" src="https://github.com/user-attachments/assets/9141d2dc-5ec3-4303-b109-f3aa407fd745" />

2. Second Call (Cache Hit - no database queries):

  <img width="1732" height="992" alt="Screenshot 2026-03-09 at 14-00-27 Symfony Profiler" src="https://github.com/user-attachments/assets/c1f487de-af4f-4140-a00c-2375e4c00f53" />

### User Feed

1. Initial Call (Cache Miss):

  <img width="1732" height="992" alt="Screenshot 2026-03-09 at 14-00-50 Symfony Profiler" src="https://github.com/user-attachments/assets/39865837-b218-4caa-abcf-15eeff03f52c" />

2. Second Call (Cache Hit - no database queries):

  <img width="1732" height="992" alt="Screenshot 2026-03-09 at 14-01-07 Symfony Profiler" src="https://github.com/user-attachments/assets/1c0e28d9-3dac-4f21-b2f5-4d9caf0b07dd" />
