### PR TITLE
fix(db): SCRUM-126 Resolve Doctrine DBAL deprecation and lock MySQL 8.4 LTS

### DIFF
--- a/.env
+++ b/.env
@@ -27,6 +27,7 @@ DEFAULT_URI=http://localhost
 ###< symfony/routing ###
 
 ###> doctrine/doctrine-bundle ###
+MYSQL_VERSION=8.4
 # Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
 # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
 #
@@ -34,7 +35,7 @@ DEFAULT_URI=http://localhost
 # DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=8.0.32&charset=utf8mb4"
 # DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=10.11.2-MariaDB&charset=utf8mb4"
 #DATABASE_URL="postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=16&charset=utf8"
-DATABASE_URL=mysql://${MYSQL_USER:-app}:${MYSQL_PASSWORD:-!ChangeMe!}@database:3306/${MYSQL_DATABASE:-app}?serverVersion=${MYSQL_VERSION:-8}&charset=${MYSQL_CHARSET:-utf8mb4}
+DATABASE_URL=mysql://${MYSQL_USER:-app}:${MYSQL_PASSWORD:-!ChangeMe!}@database:3306/${MYSQL_DATABASE:-app}?serverVersion=${MYSQL_VERSION:-8.4}&charset=${MYSQL_CHARSET:-utf8mb4}
 ###< doctrine/doctrine-bundle ###
 
 ###> lexik/jwt-authentication-bundle ###

--- a/compose.yaml
+++ b/compose.yaml
@@ -56,7 +56,7 @@ services:
       start_period: 30s
 
   database:
-    image: mysql:${MYSQL_VERSION:-8}
+    image: mysql:${MYSQL_VERSION:-8.4}
     restart: unless-stopped
     environment:
       MYSQL_DATABASE: ${MYSQL_DATABASE:-app}


### PR DESCRIPTION
**Jira**: [SCRUM-126](https://epam-team-php.atlassian.net/browse/SCRUM-126)

## Description

Resolve Doctrine DBAL deprecation and lock MySQL 8.4 LTS.

## How to roll back?

Revert this pull request.

## How has this been tested?

Manual testing was applied.

## Media attachments (optional)

### Before

<img width="1732" height="992" alt="symfony-profiler-mysql" src="https://github.com/user-attachments/assets/5b438502-83f8-4bd3-8f1b-9d6123100182" />

### After

<img width="1732" height="992" alt="image" src="https://github.com/user-attachments/assets/af85bfdf-e661-4b47-9fbe-36533b15eb24" />

