### PR TITLE
feat(tweet,profile): SCRUM-118 Implement Cache Invalidation

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -160,6 +160,12 @@ services:
             $cacheProfiles: '@cache.profiles'
             $ttl: '%cache_ttl_profile%'
 
+    Twitter\Profile\Infrastructure\Cache\Decorator\UpdateProfileCommandHandlerDecorator:
+        decorates: Twitter\Profile\Application\UseCase\UpdateProfile\UpdateProfileCommandHandlerInterface
+        arguments:
+            $inner: '@.inner'
+            $cacheProfiles: '@cache.profiles'
+
     Twitter\Tweet\Application\Message\UpdateTweetLikesCountHandler: ~
 
     Twitter\Tweet\Infrastructure\Service\TweetLikesCountUpdaterInterface:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -153,6 +153,12 @@ services:
             $cacheTweets: '@cache.tweets'
             $ttl: '%cache_ttl_feed_user%'
 
+    Twitter\Tweet\Infrastructure\Cache\Decorator\UpdateTweetCommandHandlerDecorator:
+        decorates: Twitter\Tweet\Application\UseCase\UpdateTweet\UpdateTweetCommandHandlerInterface
+        arguments:
+            $inner: '@.inner'
+            $cacheTweets: '@cache.tweets'
+
     Twitter\Profile\Infrastructure\Cache\Proxy\GetProfileQueryHandlerProxy:
         decorates: Twitter\Profile\Application\UseCase\GetProfile\GetProfileQueryHandlerInterface
         arguments:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -159,6 +159,12 @@ services:
             $inner: '@.inner'
             $cacheTweets: '@cache.tweets'
 
+    Twitter\Tweet\Infrastructure\Cache\Decorator\CreateTweetCommandHandlerDecorator:
+        decorates: Twitter\Tweet\Application\UseCase\CreateTweet\CreateTweetCommandHandlerInterface
+        arguments:
+            $inner: '@.inner'
+            $cacheTweets: '@cache.tweets'
+
     Twitter\Profile\Infrastructure\Cache\Proxy\GetProfileQueryHandlerProxy:
         decorates: Twitter\Profile\Application\UseCase\GetProfile\GetProfileQueryHandlerInterface
         arguments:

--- a/src/Profile/Infrastructure/Cache/Decorator/UpdateProfileCommandHandlerDecorator.php
+++ b/src/Profile/Infrastructure/Cache/Decorator/UpdateProfileCommandHandlerDecorator.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Profile\Infrastructure\Cache\Decorator;
+
+use Override;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use Twitter\IAM\Domain\Auth\Exception\UnauthorizedException;
+use Twitter\Profile\Application\UseCase\UpdateProfile\UpdateProfileCommand;
+use Twitter\Profile\Application\UseCase\UpdateProfile\UpdateProfileCommandHandlerInterface;
+use Twitter\Profile\Application\UseCase\UpdateProfile\UpdateProfileCommandResult;
+use Twitter\Profile\Domain\Profile\Exception\ProfileNotFoundException;
+
+final readonly class UpdateProfileCommandHandlerDecorator implements UpdateProfileCommandHandlerInterface
+{
+    public function __construct(
+        private UpdateProfileCommandHandlerInterface $inner,
+        private TagAwareCacheInterface $cacheProfiles,
+    ) {}
+
+    /**
+     * @throws ProfileNotFoundException
+     * @throws UnauthorizedException
+     */
+    #[Override]
+    public function handle(UpdateProfileCommand $command): UpdateProfileCommandResult
+    {
+        $result = $this->inner->handle($command);
+
+        $this->cacheProfiles->invalidateTags([
+            sprintf(
+                'profile_%s',
+                $command->userId,
+            ),
+        ]);
+
+        return $result;
+    }
+}

--- a/src/Tweet/Infrastructure/Cache/Decorator/CreateTweetCommandHandlerDecorator.php
+++ b/src/Tweet/Infrastructure/Cache/Decorator/CreateTweetCommandHandlerDecorator.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Tweet\Infrastructure\Cache\Decorator;
+
+use Override;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use Twitter\Tweet\Application\UseCase\CreateTweet\CreateTweetCommand;
+use Twitter\Tweet\Application\UseCase\CreateTweet\CreateTweetCommandHandlerInterface;
+use Twitter\Tweet\Application\UseCase\CreateTweet\CreateTweetCommandResult;
+
+final readonly class CreateTweetCommandHandlerDecorator implements CreateTweetCommandHandlerInterface
+{
+    public function __construct(
+        private CreateTweetCommandHandlerInterface $inner,
+        private TagAwareCacheInterface $cacheTweets,
+    ) {}
+
+    #[Override]
+    public function handle(CreateTweetCommand $command): CreateTweetCommandResult
+    {
+        $result = $this->inner->handle($command);
+
+        $this->cacheTweets->invalidateTags([
+            sprintf('user_tweets_%s',
+                $command->userId,
+            ),
+        ]);
+
+        return $result;
+    }
+}

--- a/src/Tweet/Infrastructure/Cache/Decorator/UpdateTweetCommandHandlerDecorator.php
+++ b/src/Tweet/Infrastructure/Cache/Decorator/UpdateTweetCommandHandlerDecorator.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Tweet\Infrastructure\Cache\Decorator;
+
+use Override;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use Twitter\Tweet\Application\UseCase\UpdateTweet\UpdateTweetCommand;
+use Twitter\Tweet\Application\UseCase\UpdateTweet\UpdateTweetCommandHandlerInterface;
+use Twitter\Tweet\Application\UseCase\UpdateTweet\UpdateTweetCommandResult;
+use Twitter\Tweet\Domain\Tweet\Exception\TweetAccessDeniedException;
+use Twitter\Tweet\Domain\Tweet\Exception\TweetNotFoundException;
+
+final readonly class UpdateTweetCommandHandlerDecorator implements UpdateTweetCommandHandlerInterface
+{
+    public function __construct(
+        private UpdateTweetCommandHandlerInterface $inner,
+        private TagAwareCacheInterface $cacheTweets,
+    ) {}
+
+    /**
+     * @throws TweetAccessDeniedException
+     * @throws TweetNotFoundException
+     */
+    #[Override]
+    public function handle(UpdateTweetCommand $command): UpdateTweetCommandResult
+    {
+        $result = $this->inner->handle($command);
+
+        $this->cacheTweets->invalidateTags([
+            sprintf(
+                'user_tweets_%s',
+                $command->userId,
+            ),
+        ]);
+
+        return $result;
+    }
+}

--- a/tests/Profile/Infrastructure/Cache/Decorator/UpdateProfileCommandHandlerDecoratorTest.php
+++ b/tests/Profile/Infrastructure/Cache/Decorator/UpdateProfileCommandHandlerDecoratorTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Tests\Profile\Infrastructure\Cache\Decorator;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use Twitter\Profile\Application\UseCase\UpdateProfile\UpdateProfileCommand;
+use Twitter\Profile\Application\UseCase\UpdateProfile\UpdateProfileCommandHandlerInterface;
+use Twitter\Profile\Application\UseCase\UpdateProfile\UpdateProfileCommandResult;
+use Twitter\Profile\Domain\Profile\Exception\ProfileNotFoundException;
+use Twitter\Profile\Infrastructure\Cache\Decorator\UpdateProfileCommandHandlerDecorator;
+
+#[Group('unit')]
+#[CoversClass(UpdateProfileCommandHandlerDecorator::class)]
+final class UpdateProfileCommandHandlerDecoratorTest extends TestCase
+{
+    private UpdateProfileCommandHandlerInterface&MockObject $inner;
+    private TagAwareCacheInterface&MockObject $cache;
+    private UpdateProfileCommandHandlerDecorator $decorator;
+
+    protected function setUp(): void
+    {
+        $this->inner = $this->createMock(UpdateProfileCommandHandlerInterface::class);
+        $this->cache = $this->createMock(TagAwareCacheInterface::class);
+        $this->decorator = new UpdateProfileCommandHandlerDecorator($this->inner, $this->cache);
+    }
+
+    #[Test]
+    public function itDelegatesToInnerAndInvalidatesCacheOnSuccess(): void
+    {
+        $userId = '019b5f3f-d110-7908-9177-5df439942a8b';
+
+        $command = new UpdateProfileCommand($userId, 'John', 'Bio');
+        $expectedResult = new UpdateProfileCommandResult('John', 'Bio', new DateTimeImmutable());
+
+        $this->inner
+            ->expects(self::once())
+            ->method('handle')
+            ->with($command)
+            ->willReturn($expectedResult);
+
+        $this->cache
+            ->expects(self::once())
+            ->method('invalidateTags')
+            ->with([sprintf('profile_%s', $userId)]);
+
+        $result = $this->decorator->handle($command);
+
+        self::assertSame($expectedResult, $result);
+    }
+
+    #[Test]
+    public function itDoesNotInvalidateCacheIfInnerHandlerFails(): void
+    {
+        $userId = 'user-123';
+        $command = new UpdateProfileCommand($userId, 'Faulty');
+
+        $this->inner
+            ->expects(self::once())
+            ->method('handle')
+            ->willThrowException(new ProfileNotFoundException($userId));
+
+        $this->cache
+            ->expects(self::never())
+            ->method('invalidateTags');
+
+        $this->expectException(ProfileNotFoundException::class);
+        $this->expectExceptionMessage(sprintf('Profile not found for user with id "%s"', $userId));
+
+        $this->decorator->handle($command);
+    }
+}

--- a/tests/Tweet/Infrastructure/Cache/Decorator/CreateTweetCommandHandlerDecoratorTest.php
+++ b/tests/Tweet/Infrastructure/Cache/Decorator/CreateTweetCommandHandlerDecoratorTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Tests\Tweet\Infrastructure\Cache\Decorator;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use Twitter\Tweet\Application\UseCase\CreateTweet\CreateTweetCommand;
+use Twitter\Tweet\Application\UseCase\CreateTweet\CreateTweetCommandHandlerInterface;
+use Twitter\Tweet\Application\UseCase\CreateTweet\CreateTweetCommandResult;
+use Twitter\Tweet\Domain\Tweet\Exception\UserNotFoundException;
+use Twitter\Tweet\Infrastructure\Cache\Decorator\CreateTweetCommandHandlerDecorator;
+
+#[Group('unit')]
+#[CoversClass(CreateTweetCommandHandlerDecorator::class)]
+final class CreateTweetCommandHandlerDecoratorTest extends TestCase
+{
+    private CreateTweetCommandHandlerInterface&MockObject $inner;
+    private TagAwareCacheInterface&MockObject $cache;
+    private CreateTweetCommandHandlerDecorator $decorator;
+
+    protected function setUp(): void
+    {
+        $this->inner = $this->createMock(CreateTweetCommandHandlerInterface::class);
+        $this->cache = $this->createMock(TagAwareCacheInterface::class);
+        $this->decorator = new CreateTweetCommandHandlerDecorator($this->inner, $this->cache);
+    }
+
+    #[Test]
+    public function itDelegatesToInnerAndInvalidatesCacheOnSuccess(): void
+    {
+        $userId = '019b5f3f-d110-7908-9177-5df439942a8b';
+        $tweetId = '019b5f3f-d110-7908-9177-5df439942a8c';
+
+        $command = new CreateTweetCommand($userId, 'Some tweet content');
+        $expectedResult = new CreateTweetCommandResult($tweetId, new DateTimeImmutable(), new DateTimeImmutable());
+
+        $this->inner
+            ->expects(self::once())
+            ->method('handle')
+            ->with($command)
+            ->willReturn($expectedResult);
+
+        $this->cache
+            ->expects(self::once())
+            ->method('invalidateTags')
+            ->with([sprintf('user_tweets_%s', $userId)]);
+
+        $result = $this->decorator->handle($command);
+
+        self::assertSame($expectedResult, $result);
+    }
+
+    #[Test]
+    public function itDoesNotInvalidateCacheIfInnerHandlerFails(): void
+    {
+        $userId = 'user-123';
+        $command = new CreateTweetCommand($userId, 'Faulty content');
+
+        $this->inner
+            ->expects(self::once())
+            ->method('handle')
+            ->willThrowException(new UserNotFoundException($userId));
+
+        $this->cache
+            ->expects(self::never())
+            ->method('invalidateTags');
+
+        $this->expectException(UserNotFoundException::class);
+        $this->expectExceptionMessage(sprintf('User with id "%s" not found', $userId));
+
+        $this->decorator->handle($command);
+    }
+}

--- a/tests/Tweet/Infrastructure/Cache/Decorator/UpdateTweetCommandHandlerDecoratorTest.php
+++ b/tests/Tweet/Infrastructure/Cache/Decorator/UpdateTweetCommandHandlerDecoratorTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Tests\Tweet\Infrastructure\Cache\Decorator;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use Twitter\Tweet\Application\UseCase\UpdateTweet\UpdateTweetCommand;
+use Twitter\Tweet\Application\UseCase\UpdateTweet\UpdateTweetCommandHandlerInterface;
+use Twitter\Tweet\Application\UseCase\UpdateTweet\UpdateTweetCommandResult;
+use Twitter\Tweet\Domain\Tweet\Exception\TweetNotFoundException;
+use Twitter\Tweet\Infrastructure\Cache\Decorator\UpdateTweetCommandHandlerDecorator;
+
+#[Group('unit')]
+#[CoversClass(UpdateTweetCommandHandlerDecorator::class)]
+final class UpdateTweetCommandHandlerDecoratorTest extends TestCase
+{
+    private UpdateTweetCommandHandlerInterface&MockObject $inner;
+    private TagAwareCacheInterface&MockObject $cache;
+    private UpdateTweetCommandHandlerDecorator $decorator;
+
+    protected function setUp(): void
+    {
+        $this->inner = $this->createMock(UpdateTweetCommandHandlerInterface::class);
+        $this->cache = $this->createMock(TagAwareCacheInterface::class);
+        $this->decorator = new UpdateTweetCommandHandlerDecorator($this->inner, $this->cache);
+    }
+
+    #[Test]
+    public function itDelegatesToInnerAndInvalidatesCacheOnSuccess(): void
+    {
+        $userId = '019b5f3f-d110-7908-9177-5df439942a8b';
+        $tweetId = '019b5f3f-d110-7908-9177-5df439942a8c';
+
+        $command = new UpdateTweetCommand($userId, $tweetId, 'Updated content');
+        $expectedResult = new UpdateTweetCommandResult('Updated content', new DateTimeImmutable());
+
+        $this->inner
+            ->expects(self::once())
+            ->method('handle')
+            ->with($command)
+            ->willReturn($expectedResult);
+
+        $this->cache
+            ->expects(self::once())
+            ->method('invalidateTags')
+            ->with([sprintf('user_tweets_%s', $userId)]);
+
+        $result = $this->decorator->handle($command);
+
+        self::assertSame($expectedResult, $result);
+    }
+
+    #[Test]
+    public function itDoesNotInvalidateCacheIfInnerHandlerFails(): void
+    {
+        $userId = 'user-123';
+        $tweetId = 'tweet-456';
+        $command = new UpdateTweetCommand($userId, $tweetId, 'Faulty content');
+
+        $this->inner
+            ->expects(self::once())
+            ->method('handle')
+            ->willThrowException(new TweetNotFoundException($tweetId));
+
+        $this->cache
+            ->expects(self::never())
+            ->method('invalidateTags');
+
+        $this->expectException(TweetNotFoundException::class);
+        $this->expectExceptionMessage(sprintf('Tweet "%s" not found.', $tweetId));
+
+        $this->decorator->handle($command);
+    }
+}


### PR DESCRIPTION
**Jira**: [SCRUM-118](https://epam-team-php.atlassian.net/browse/SCRUM-118)

## Description

Implemented cache invalidation decorators for Profile and Tweet command handlers to ensure immediate data consistency upon creation or update.

## How to roll back?

Revert this pull request.

## How has this been tested?

```
$ docker compose exec php ./vendor/bin/phpunit tests/Profile/Infrastructure/Cache/Decorator/UpdateProfileCommandHandlerDecoratorTest.php tests/Tweet/Infrastructure/Cache/Decorator --display-all-issues --testdox --group unit

PHPUnit 12.5.14 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.18
Configuration: /app/phpunit.dist.xml

......                                                              6 / 6 (100%)

Time: 00:00.030, Memory: 16.00 MB

Create Tweet Command Handler Decorator (Twitter\Tests\Tweet\Infrastructure\Cache\Decorator\CreateTweetCommandHandlerDecorator)
 ✔ It delegates to inner and invalidates cache on success
 ✔ It does not invalidate cache if inner handler fails

Update Profile Command Handler Decorator (Twitter\Tests\Profile\Infrastructure\Cache\Decorator\UpdateProfileCommandHandlerDecorator)
 ✔ It delegates to inner and invalidates cache on success
 ✔ It does not invalidate cache if inner handler fails

Update Tweet Command Handler Decorator (Twitter\Tests\Tweet\Infrastructure\Cache\Decorator\UpdateTweetCommandHandlerDecorator)
 ✔ It delegates to inner and invalidates cache on success
 ✔ It does not invalidate cache if inner handler fails

OK (6 tests, 27 assertions)
```

## Media attachments (optional)

N/A
