### PR TITLE
hotfix(like): SCRUM-128 Fix PHPUnit Notices for Mock Objects Without Expectations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
         "friendsofphp/php-cs-fixer": "*",
         "php-cs-fixer/shim": "^3.94.2",
         "phpstan/phpstan": "^2.1.40",
-        "phpstan/phpstan-doctrine": "^2.0.18",
+        "phpstan/phpstan-doctrine": "^2.0.19",
         "phpstan/phpstan-symfony": "^2.0.15",
         "phpunit/phpunit": "^12.5.14",
         "symfony/browser-kit": "7.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4a5018ded4adbf1ebbc4a041fbfacda4",
+    "content-hash": "dbb49189441306b7e5e824e0b0e46dd2",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -8569,16 +8569,16 @@
         },
         {
             "name": "phpstan/phpstan-doctrine",
-            "version": "2.0.18",
+            "version": "2.0.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-doctrine.git",
-                "reference": "44a216a5cd9fe52be489dcf1e2d565c473daa1ca"
+                "reference": "27cd48bc59b4913464095288fbf197a66dacb9b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/44a216a5cd9fe52be489dcf1e2d565c473daa1ca",
-                "reference": "44a216a5cd9fe52be489dcf1e2d565c473daa1ca",
+                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/27cd48bc59b4913464095288fbf197a66dacb9b8",
+                "reference": "27cd48bc59b4913464095288fbf197a66dacb9b8",
                 "shasum": ""
             },
             "require": {
@@ -8639,9 +8639,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-doctrine/issues",
-                "source": "https://github.com/phpstan/phpstan-doctrine/tree/2.0.18"
+                "source": "https://github.com/phpstan/phpstan-doctrine/tree/2.0.19"
             },
-            "time": "2026-02-24T10:01:00+00:00"
+            "time": "2026-03-10T16:59:12+00:00"
         },
         {
             "name": "phpstan/phpstan-symfony",
@@ -10262,16 +10262,16 @@
         },
         {
             "name": "symfony/debug-bundle",
-            "version": "v7.4.0",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug-bundle.git",
-                "reference": "329383fb895353e3c8ab792cc35c4a7e7b17881b"
+                "reference": "7affd8924ef9a7739ec53284c2fc30afeeae7124"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug-bundle/zipball/329383fb895353e3c8ab792cc35c4a7e7b17881b",
-                "reference": "329383fb895353e3c8ab792cc35c4a7e7b17881b",
+                "url": "https://api.github.com/repos/symfony/debug-bundle/zipball/7affd8924ef9a7739ec53284c2fc30afeeae7124",
+                "reference": "7affd8924ef9a7739ec53284c2fc30afeeae7124",
                 "shasum": ""
             },
             "require": {
@@ -10313,7 +10313,7 @@
             "description": "Provides a tight integration of the Symfony VarDumper component and the ServerLogCommand from MonologBridge into the Symfony full-stack framework",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/debug-bundle/tree/v7.4.0"
+                "source": "https://github.com/symfony/debug-bundle/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -10333,7 +10333,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-24T13:56:35+00:00"
+            "time": "2026-03-03T07:48:48+00:00"
         },
         {
             "name": "symfony/dom-crawler",
@@ -10409,16 +10409,16 @@
         },
         {
             "name": "symfony/web-profiler-bundle",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/web-profiler-bundle.git",
-                "reference": "952fbb5ea12e101e05510069eacf01e169955100"
+                "reference": "da9e91746fc9c575be8b5ff466b7572d98e7e1ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/952fbb5ea12e101e05510069eacf01e169955100",
-                "reference": "952fbb5ea12e101e05510069eacf01e169955100",
+                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/da9e91746fc9c575be8b5ff466b7572d98e7e1ae",
+                "reference": "da9e91746fc9c575be8b5ff466b7572d98e7e1ae",
                 "shasum": ""
             },
             "require": {
@@ -10475,7 +10475,7 @@
                 "dev"
             ],
             "support": {
-                "source": "https://github.com/symfony/web-profiler-bundle/tree/v7.4.6"
+                "source": "https://github.com/symfony/web-profiler-bundle/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -10495,7 +10495,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-11T16:03:16+00:00"
+            "time": "2026-03-03T13:57:00+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/config/reference.php
+++ b/config/reference.php
@@ -1514,8 +1514,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type MercureConfig = array{
  *     hubs?: array<string, array{ // Default: []
- *         url?: scalar|Param|null, // URL of the hub's publish endpoint
- *         public_url?: scalar|Param|null, // URL of the hub's public endpoint // Default: null
+ *         url?: scalar|Param|null, // URL of the hub's publish endpoint // Default: null
+ *         public_url?: scalar|Param|null, // URL of the hub's public endpoint
  *         jwt?: string|array{ // JSON Web Token configuration.
  *             value?: scalar|Param|null, // JSON Web Token to use to publish to this hub.
  *             provider?: scalar|Param|null, // The ID of a service to call to provide the JSON Web Token.

--- a/tests/Tweet/Application/EventSubscriber/LikeMessageBridgeSubscriberTest.php
+++ b/tests/Tweet/Application/EventSubscriber/LikeMessageBridgeSubscriberTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Twitter\Tests\Tweet\Application\EventSubscriber;
 
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -31,6 +32,7 @@ final class LikeMessageBridgeSubscriberTest extends TestCase
     }
 
     #[Test]
+    #[AllowMockObjectsWithoutExpectations]
     public function getSubscribedEventsReturnsCorrectMapping(): void
     {
         $events = LikeMessageBridgeSubscriber::getSubscribedEvents();

--- a/tests/Tweet/Infrastructure/Service/TweetLikesCountUpdaterTest.php
+++ b/tests/Tweet/Infrastructure/Service/TweetLikesCountUpdaterTest.php
@@ -39,7 +39,7 @@ final class TweetLikesCountUpdaterTest extends TestCase
             ->expects(self::once())
             ->method('executeStatement')
             ->with(
-                self::stringContains('UPDATE tweets SET likes_count'),
+                self::stringContains(/* @lang text */ 'UPDATE tweets SET likes_count'),
                 self::callback(function (array $params): bool {
                     return isset($params['delta']) && 1 === $params['delta']
                         && isset($params['id']);

--- a/tests/Tweet/Infrastructure/Service/TweetLikesCountUpdaterTest.php
+++ b/tests/Tweet/Infrastructure/Service/TweetLikesCountUpdaterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Twitter\Tests\Tweet\Infrastructure\Service;
 
 use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -29,6 +30,7 @@ final class TweetLikesCountUpdaterTest extends TestCase
     }
 
     #[Test]
+    #[AllowMockObjectsWithoutExpectations]
     public function updateCountReturnsNewCountWhenTweetExists(): void
     {
         $tweetId = '019b5f3f-d110-7908-9177-5df439942a8b';
@@ -80,6 +82,7 @@ final class TweetLikesCountUpdaterTest extends TestCase
     }
 
     #[Test]
+    #[AllowMockObjectsWithoutExpectations]
     public function updateCountPassesCorrectBinaryId(): void
     {
         $tweetId = '019b5f3f-d110-7908-9177-5df439942a8b';


### PR DESCRIPTION
**Jira**: [SCRUM-128](https://epam-team-php.atlassian.net/browse/SCRUM-128)

## Description

Closes #93 

## How to roll back?

Revert this pull request.

## How has this been tested?

```text
Runtime:       PHP 8.4.18
Configuration: /app/phpunit.dist.xml

...............................................................  63 / 173 ( 36%)
............................................................... 126 / 173 ( 72%)
...............................................                 173 / 173 (100%)

Time: 00:07.274, Memory: 24.00 MB

OK (173 tests, 487 assertions)
```