### PR TITLE
Scrum 120 implement like action locker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,17 @@ csdr:
 test:
 	docker compose exec php vendor/bin/phpunit
 
+testdetails:
+	docker compose exec php vendor/bin/phpunit --display-all-issues --colors=always
+
+dump-auto:
+	docker compose exec php composer dump-autoload
+
 about:
 	docker compose exec php php bin/console about
+
+container:
+	docker compose exec php php bin/console debug:container
 
 start:
 	docker compose up --wait -d
@@ -25,9 +34,16 @@ start:
 stop:
 	docker compose down
 
-allchecks: stan cs test
+worker:
+	docker compose exec php php bin/console app:moderation:flush-worker
+
+phpmetrics:
+	docker compose exec php ./vendor/bin/phpmetrics --report-html=phpmetrics3 ./src
+
+allchecks: stan csdr testdetails
 
 r: router
 cc: cache-clear
 s: stan
 t: test
+td: testdetails

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,6 +4,7 @@ parameters:
     cache_ttl_feed_main: '%env(int:CACHE_TTL_FEED_MAIN)%'
     cache_ttl_feed_user: '%env(int:CACHE_TTL_FEED_USER)%'
     cache_ttl_profile: '%env(int:CACHE_TTL_PROFILE)%'
+    like_toggle_lock_ttl_seconds: 5
 
 services:
     _defaults:
@@ -82,6 +83,8 @@ services:
     Twitter\Like\Application\UseCase\ToggleLike\ToggleLikeCommandHandler:
         arguments:
             $likeRepository: '@Twitter\Like\Domain\Like\Model\LikeRepository'
+            
+        Twitter\Like\Application\UseCase\ToggleLike\ToggleLikeCommandHandlerInterface: '@Twitter\Like\Application\UseCase\ToggleLike\ToggleLikeCommandHandler'
     
     Twitter\Profile\Application\UseCase\GetProfile\GetProfileQueryHandler:
         arguments:
@@ -204,6 +207,12 @@ services:
         tags:
             - { name: kernel.event_subscriber }
     
+    Twitter\Like\Application\UseCase\ToggleLike\LockingToggleLikeCommandHandler:
+        decorates: Twitter\Like\Application\UseCase\ToggleLike\ToggleLikeCommandHandlerInterface
+        arguments:
+            $inner: '@.inner'
+            $ttlSeconds: '%like_toggle_lock_ttl_seconds%'
+    
     Prometheus\Storage\InMemory:
         public: true
     
@@ -211,6 +220,8 @@ services:
         class: Prometheus\CollectorRegistry
         arguments:
             - '@Prometheus\Storage\InMemory'
+    
+    
     
     # DoctrineClearSubscriber commented out: redundant with DoctrineResetSubscriber.
     # In FrankenPHP worker mode, resetManager() already clears the identity map; this subscriber's

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -84,7 +84,13 @@ services:
         arguments:
             $likeRepository: '@Twitter\Like\Domain\Like\Model\LikeRepository'
             
-        Twitter\Like\Application\UseCase\ToggleLike\ToggleLikeCommandHandlerInterface: '@Twitter\Like\Application\UseCase\ToggleLike\ToggleLikeCommandHandler'
+    Twitter\Like\Application\UseCase\ToggleLike\ToggleLikeCommandHandlerInterface: '@Twitter\Like\Application\UseCase\ToggleLike\ToggleLikeCommandHandler'
+    
+    Twitter\Like\Application\UseCase\ToggleLike\LockingToggleLikeCommandHandler:
+        decorates: Twitter\Like\Application\UseCase\ToggleLike\ToggleLikeCommandHandlerInterface
+        arguments:
+            $inner: '@.inner'
+            $ttlSeconds: '%like_toggle_lock_ttl_seconds%'
     
     Twitter\Profile\Application\UseCase\GetProfile\GetProfileQueryHandler:
         arguments:
@@ -206,12 +212,6 @@ services:
     Twitter\Metrics\EventSubscriber\HttpMetricsSubscriber:
         tags:
             - { name: kernel.event_subscriber }
-    
-    Twitter\Like\Application\UseCase\ToggleLike\LockingToggleLikeCommandHandler:
-        decorates: Twitter\Like\Application\UseCase\ToggleLike\ToggleLikeCommandHandlerInterface
-        arguments:
-            $inner: '@.inner'
-            $ttlSeconds: '%like_toggle_lock_ttl_seconds%'
     
     Prometheus\Storage\InMemory:
         public: true

--- a/src/Like/Application/UseCase/ToggleLike/LockingToggleLikeCommandHandler.php
+++ b/src/Like/Application/UseCase/ToggleLike/LockingToggleLikeCommandHandler.php
@@ -7,7 +7,6 @@ namespace Twitter\Like\Application\UseCase\ToggleLike;
 use Symfony\Component\Lock\LockFactory;
 use Twitter\Like\Domain\Like\Exception\LikeActionLockedException;
 
-
 final readonly class LockingToggleLikeCommandHandler implements ToggleLikeCommandHandlerInterface
 {
     public function __construct(

--- a/src/Like/Application/UseCase/ToggleLike/LockingToggleLikeCommandHandler.php
+++ b/src/Like/Application/UseCase/ToggleLike/LockingToggleLikeCommandHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Like\Application\UseCase\ToggleLike;
+
+use Symfony\Component\Lock\LockFactory;
+use Twitter\Like\Domain\Like\Exception\LikeActionLockedException;
+
+
+final readonly class LockingToggleLikeCommandHandler implements ToggleLikeCommandHandlerInterface
+{
+    public function __construct(
+        private ToggleLikeCommandHandlerInterface $inner,
+        private LockFactory $lockFactory,
+        private int $ttlSeconds,
+    ) {}
+
+    /**
+     * @throws LikeActionLockedException
+     */
+    public function handle(ToggleLikeCommand $command): ToggleLikeCommandResult
+    {
+        $lock = $this->lockFactory->createLock(
+            $this->lockLikeKey($command),
+            $this->ttlSeconds,
+        );
+
+        if (!$lock->acquire(false)) {
+            throw new LikeActionLockedException($command->tweetId, $command->userId);
+        }
+
+        try {
+            return $this->inner->handle($command);
+        } finally {
+            $lock->release();
+        }
+    }
+
+    private function lockLikeKey(ToggleLikeCommand $command): string
+    {
+        return sprintf(
+            'lock_like_user_%s_tweet_%s',
+            $command->userId,
+            $command->tweetId,
+        );
+    }
+}

--- a/src/Like/Application/UseCase/ToggleLike/ToggleLikeCommandHandler.php
+++ b/src/Like/Application/UseCase/ToggleLike/ToggleLikeCommandHandler.php
@@ -11,7 +11,7 @@ use Twitter\Like\Domain\Like\Exception\LikeAlreadyExistsException;
 use Twitter\Like\Domain\Like\Model\Like;
 use Twitter\Like\Domain\Like\Model\LikeRepository;
 
-final readonly class ToggleLikeCommandHandler
+final readonly class ToggleLikeCommandHandler implements ToggleLikeCommandHandlerInterface
 {
     public function __construct(
         private LikeRepository $likeRepository,

--- a/src/Like/Application/UseCase/ToggleLike/ToggleLikeCommandHandlerInterface.php
+++ b/src/Like/Application/UseCase/ToggleLike/ToggleLikeCommandHandlerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Like\Application\UseCase\ToggleLike;
+
+use Twitter\Like\Domain\Like\Exception\LikeAlreadyExistsException;
+
+interface ToggleLikeCommandHandlerInterface
+{
+    /**
+     * @throws LikeAlreadyExistsException
+     */
+    public function handle(ToggleLikeCommand $command): ToggleLikeCommandResult;
+}

--- a/src/Like/Domain/Like/Exception/LikeActionLockedException.php
+++ b/src/Like/Domain/Like/Exception/LikeActionLockedException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Like\Domain\Like\Exception;
+
+use Exception;
+
+final class LikeActionLockedException extends Exception
+{
+    public const string ERROR_CODE = 'LIKE_ACTION_LOCKED';
+
+    public function __construct(
+        string $tweetId,
+        string $userId,
+    ) {
+        parent::__construct(
+            sprintf(
+                'Like action for tweet "%s" is LOCKED by user "%s" is already being processed.',
+                $tweetId,
+                $userId,
+            ),
+        );
+    }
+}

--- a/src/Like/UI/REST/Controller/ToggleLikeController.php
+++ b/src/Like/UI/REST/Controller/ToggleLikeController.php
@@ -12,14 +12,14 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Twitter\IAM\Domain\User\Model\User;
 use Twitter\Like\Application\UseCase\ToggleLike\ToggleLikeCommand;
-use Twitter\Like\Application\UseCase\ToggleLike\ToggleLikeCommandHandler;
+use Twitter\Like\Application\UseCase\ToggleLike\ToggleLikeCommandHandlerInterface;
 use Twitter\Like\Domain\Like\Exception\LikeAlreadyExistsException;
 
 #[Route('api/tweets/{tweetId}/likes/toggle', name: 'api_tweets_like_toggle', methods: [Request::METHOD_POST])]
 final class ToggleLikeController extends AbstractController
 {
     public function __construct(
-        private readonly ToggleLikeCommandHandler $handler,
+        private readonly ToggleLikeCommandHandlerInterface $handler,
     ) {}
 
     /**

--- a/src/Shared/Infrastructure/EventSubscriber/ExceptionSubscriber.php
+++ b/src/Shared/Infrastructure/EventSubscriber/ExceptionSubscriber.php
@@ -29,6 +29,7 @@ use Twitter\Profile\Domain\Profile\Exception\UserNotFoundException as ProfileUse
 use Twitter\Tweet\Domain\Tweet\Exception\TweetAccessDeniedException;
 use Twitter\Tweet\Domain\Tweet\Exception\TweetNotFoundException;
 use Twitter\Tweet\Domain\Tweet\Exception\UserNotFoundException as TweetUserNotFoundExceptionAlias;
+use Twitter\Like\Domain\Like\Exception\LikeActionLockedException;
 
 final readonly class ExceptionSubscriber implements EventSubscriberInterface
 {
@@ -104,6 +105,11 @@ final readonly class ExceptionSubscriber implements EventSubscriberInterface
             'message' => 'The tweet has already been liked by this user',
             'status' => Response::HTTP_CONFLICT,
         ],
+        LikeActionLockedException::class => [
+            'code' => 'LIKE_ACTION_LOCKED',
+            'message' => 'The tweet has already been locked by this user',
+            'status' => Response::HTTP_TOO_MANY_REQUESTS,
+        ]
     ];
 
     public function __construct(

--- a/src/Shared/Infrastructure/EventSubscriber/ExceptionSubscriber.php
+++ b/src/Shared/Infrastructure/EventSubscriber/ExceptionSubscriber.php
@@ -22,6 +22,7 @@ use Twitter\IAM\Domain\Auth\Exception\ValidationErrorException;
 use Twitter\IAM\Domain\User\Exception\InvalidEmailException;
 use Twitter\IAM\Domain\User\Exception\InvalidPasswordException;
 use Twitter\IAM\Domain\User\Exception\UserAlreadyExistsException;
+use Twitter\Like\Domain\Like\Exception\LikeActionLockedException;
 use Twitter\Like\Domain\Like\Exception\LikeAlreadyExistsException;
 use Twitter\Profile\Domain\Profile\Exception\ProfileAlreadyExistsException;
 use Twitter\Profile\Domain\Profile\Exception\ProfileNotFoundException;
@@ -29,7 +30,6 @@ use Twitter\Profile\Domain\Profile\Exception\UserNotFoundException as ProfileUse
 use Twitter\Tweet\Domain\Tweet\Exception\TweetAccessDeniedException;
 use Twitter\Tweet\Domain\Tweet\Exception\TweetNotFoundException;
 use Twitter\Tweet\Domain\Tweet\Exception\UserNotFoundException as TweetUserNotFoundExceptionAlias;
-use Twitter\Like\Domain\Like\Exception\LikeActionLockedException;
 
 final readonly class ExceptionSubscriber implements EventSubscriberInterface
 {
@@ -109,7 +109,7 @@ final readonly class ExceptionSubscriber implements EventSubscriberInterface
             'code' => 'LIKE_ACTION_LOCKED',
             'message' => 'The tweet has already been locked by this user',
             'status' => Response::HTTP_TOO_MANY_REQUESTS,
-        ]
+        ],
     ];
 
     public function __construct(

--- a/tests/Like/Application/UseCase/ToggleLike/LockingToggleLikeCommandHandlerTest.php
+++ b/tests/Like/Application/UseCase/ToggleLike/LockingToggleLikeCommandHandlerTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\tests\Like\Application\UseCase\ToggleLike;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\SharedLockInterface;
+use Twitter\Like\Application\UseCase\ToggleLike\LockingToggleLikeCommandHandler;
+use Twitter\Like\Application\UseCase\ToggleLike\ToggleLikeCommand;
+use Twitter\Like\Application\UseCase\ToggleLike\ToggleLikeCommandHandlerInterface;
+use Twitter\Like\Application\UseCase\ToggleLike\ToggleLikeCommandResult;
+use Twitter\Like\Domain\Like\Exception\LikeActionLockedException;
+
+final class LockingToggleLikeCommandHandlerTest extends TestCase
+{
+    public function testThrowsExceptionWhenLockIsNotAcquired(): void
+    {
+        $command = new ToggleLikeCommand(
+            'tweet-123',
+            'user-456',
+        );
+
+        $innerHandler = $this->createMock(ToggleLikeCommandHandlerInterface::class);
+        $innerHandler
+            ->expects($this->never())
+            ->method('handle');
+
+        $lock = $this->createMock(SharedLockInterface::class);
+        $lock
+            ->expects($this->once())
+            ->method('acquire')
+            ->with(false)
+            ->willReturn(false);
+
+        $lock
+            ->expects($this->never())
+            ->method('release');
+
+        $lockFactory = $this->createMock(LockFactory::class);
+        $lockFactory
+            ->expects($this->once())
+            ->method('createLock')
+            ->with(
+                'lock_like_user_user-456_tweet_tweet-123',
+                5,
+            )
+            ->willReturn($lock);
+
+        $handler = new LockingToggleLikeCommandHandler(
+            $innerHandler,
+            $lockFactory,
+            5,
+        );
+
+        $this->expectException(LikeActionLockedException::class);
+
+        $handler->handle($command);
+    }
+
+    public function testDelegatesToInnerHandlerWhenLockIsAcquired(): void
+    {
+        $command = new ToggleLikeCommand(
+            'tweet-123',
+            'user-456',
+        );
+
+        $expectedResult = new ToggleLikeCommandResult(true);
+
+        $innerHandler = $this->createMock(ToggleLikeCommandHandlerInterface::class);
+        $innerHandler
+            ->expects($this->once())
+            ->method('handle')
+            ->with($command)
+            ->willReturn($expectedResult);
+
+        $lock = $this->createMock(SharedLockInterface::class);
+        $lock
+            ->expects($this->once())
+            ->method('acquire')
+            ->with(false)
+            ->willReturn(true);
+
+        $lock
+            ->expects($this->once())
+            ->method('release');
+
+        $lockFactory = $this->createMock(LockFactory::class);
+        $lockFactory
+            ->expects($this->once())
+            ->method('createLock')
+            ->with(
+                'lock_like_user_user-456_tweet_tweet-123',
+                5,
+            )
+            ->willReturn($lock);
+
+        $handler = new LockingToggleLikeCommandHandler(
+            $innerHandler,
+            $lockFactory,
+            5,
+        );
+
+        $result = $handler->handle($command);
+
+        self::assertSame($expectedResult, $result);
+    }
+
+    public function testReleasesLockWhenInnerHandlerThrows(): void
+    {
+        $command = new ToggleLikeCommand(
+            'tweet-123',
+            'user-456',
+        );
+
+        $innerHandler = $this->createMock(ToggleLikeCommandHandlerInterface::class);
+        $innerHandler
+            ->expects($this->once())
+            ->method('handle')
+            ->with($command)
+            ->willThrowException(new RuntimeException('Boom'));
+
+        $lock = $this->createMock(SharedLockInterface::class);
+        $lock
+            ->expects($this->once())
+            ->method('acquire')
+            ->with(false)
+            ->willReturn(true);
+
+        $lock
+            ->expects($this->once())
+            ->method('release');
+
+        $lockFactory = $this->createMock(LockFactory::class);
+        $lockFactory
+            ->expects($this->once())
+            ->method('createLock')
+            ->with(
+                'lock_like_user_user-456_tweet_tweet-123',
+                5,
+            )
+            ->willReturn($lock);
+
+        $handler = new LockingToggleLikeCommandHandler(
+            $innerHandler,
+            $lockFactory,
+            5,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Boom');
+
+        $handler->handle($command);
+    }
+}


### PR DESCRIPTION
## Description

Implement Redis-based user action lock for `ToggleLike` to prevent double-click issues and race conditions on like requests.

### What changed
- Added `LockingToggleLikeCommandHandler` as a decorator over `ToggleLikeCommandHandler`
- Added Redis lock acquisition before processing like toggle
- Lock key format:
  `lock_like_user_{userId}_tweet_{tweetId}`
- Lock is acquired in non-blocking mode
- Added `LikeActionLockedException` for fast-fail on concurrent duplicate requests
- Mapped `LikeActionLockedException` to HTTP `429 Too Many Requests` in shared `ExceptionSubscriber`
- Added handler interface wiring so controller depends on abstraction instead of concrete handler
- Added configurable lock TTL parameter (`5` seconds)

### Behavior
- First request for the same `(userId, tweetId)` acquires the lock and is processed normally
- Second simultaneous request fails fast without entering toggle logic
- Lock is released in `finally`
- TTL remains as a fail-safe in case the process crashes before release

### Notes
- Lock protects only the like action critical section
- RabbitMQ-based async counter updates remain unchanged
- This change does not alter the existing async likes count pipeline

## How to roll back?

Revert this pull request.

## How has this been tested?

### Manual testing
1. Sent a like request for a tweet as an authenticated user
2. Verified the request is processed successfully
3. Sent two near-simultaneous like requests for the same `tweetId` and `userId`
4. Verified:
   - one request succeeds
   - the second request returns HTTP `429`
   - the like state is not toggled back by the second request

### Redis verification
- Observed Redis `MONITOR` output during like processing
- Confirmed lock lifecycle:
  - lock acquisition
  - TTL assignment
  - safe release after handler completion

### Automated tests
- Added unit tests for `LockingToggleLikeCommandHandler`
- Covered scenarios:
  - lock is not acquired -> exception is thrown
  - lock is acquired -> inner handler is executed
  - inner handler throws -> lock is still released in `finally`
