### PR TITLE
chore(git-hooks): SCRUM-38 Add Git Hooks

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -21,7 +21,7 @@ $finder = new Finder()
 return new Config()
     ->setRiskyAllowed(true)
     ->setUsingCache(true)
-    ->setCacheFile(__DIR__.'/.phpunit.result.cache')
+    ->setCacheFile(__DIR__.'/.php-cs-fixer.cache')
     ->setRules([
         '@Symfony' => true,
         'strict_param' => true,

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -41,6 +41,19 @@ To use the [message template](../.github/.gitmessage), change Git config local s
 git config --local commit.template .github/.gitmessage
 ```
 
+## Git Hooks (Lefthook)
+
+The project uses [Lefthook](https://lefthook.dev/) to automate code quality checks.
+
+- **pre-commit**: Runs `php-cs-fixer` (auto-fixing style) and `phpstan` on staged `.php` files.
+- **pre-push**: Runs all PHPUnit tests.
+
+To install the hooks, run:
+
+```sh
+lefthook install
+```
+
 ## Prohibited
 
 - Direct commits or force-push to `main` and `develop`

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,15 @@
+pre-commit:
+    parallel: true
+    jobs:
+        -   run: docker compose exec -T php ./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php {staged_files}
+            glob: "*.php"
+            stage_fixed: true
+
+        -   run: docker compose exec -T php ./vendor/bin/phpstan analyse -c phpstan.dist.neon --no-interaction --memory-limit=512M {staged_files}
+            glob: "*.php"
+            exclude: '\.php-cs-fixer\.dist\.php'
+
+pre-push:
+    parallel: true
+    jobs:
+        -   run: docker compose exec -T php ./vendor/bin/phpunit --stop-on-failure --stop-on-error --colors=always


### PR DESCRIPTION
**Jira**: [SCRUM-38](https://epam-team-php.atlassian.net/browse/SCRUM-38)

## Description

Introduce Lefthook for automated code quality control during local development.

## How to roll back?

Revert this pull request.

## How has this been tested?

Manual testing was applied:

```
$ git commit -m 'docs(git-workflow): SCRUM-38 Update Git Workflow with Lefthook documentation'
╭──────────────────────────────────────╮
│ 🥊 lefthook v2.1.4  hook: pre-commit │
╰──────────────────────────────────────╯
│  docker compose exec -T php ./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php {staged_files} (skip) no files for inspection
│  docker compose exec -T php ./vendor/bin/phpstan analyse -c phpstan.dist.neon --no-interaction --memory-limit=512M {staged_files} (skip) no files for inspection
                                      
  ────────────────────────────────────
summary: (done in 0.02 seconds)       
[feature/SCRUM-38-add-git-hooks 229b909] docs(git-workflow): SCRUM-38 Update Git Workflow with Lefthook documentation
 1 file changed, 13 insertions(+)
```

```
$ git push origin -u feature/SCRUM-38-add-git-hooks 
╭────────────────────────────────────╮
│ 🥊 lefthook v2.1.4  hook: pre-push │
╰────────────────────────────────────╯
┃  docker compose exec -T php ./vendor/bin/phpunit --stop-on-failure --stop-on-error --colors=always ❯ 

PHPUnit 12.5.14 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.19
Configuration: /app/phpunit.dist.xml

...............................................................  63 / 193 ( 32%)
............................................................... 126 / 193 ( 65%)
............................................................... 189 / 193 ( 97%)
....                                                            193 / 193 (100%)

Time: 00:08.897, Memory: 24.00 MB

OK (193 tests, 587 assertions)

                                      
  ────────────────────────────────────
summary: (done in 9.58 seconds)       
✔️ docker compose exec -T php ./vendor/bin/phpunit --stop-on-failure --stop-on-error --colors=always (9.58 seconds)
Enumerating objects: 14, done.
Counting objects: 100% (14/14), done.
Delta compression using up to 8 threads
Compressing objects: 100% (10/10), done.
Writing objects: 100% (10/10), 1.52 KiB | 1.52 MiB/s, done.
Total 10 (delta 6), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (6/6), completed with 4 local objects.
remote: 
remote: Create a pull request for 'feature/SCRUM-38-add-git-hooks' on GitHub by visiting:
remote:      https://github.com/CPAprince/Twitter/pull/new/feature/SCRUM-38-add-git-hooks
remote: 
To https://github.com/CPAprince/Twitter.git
 * [new branch]      feature/SCRUM-38-add-git-hooks -> feature/SCRUM-38-add-git-hooks
branch 'feature/SCRUM-38-add-git-hooks' set up to track 'origin/feature/SCRUM-38-add-git-hooks'.
```

## Media attachments (optional)

N/A
