### PR TITLE
Adds migration with indexes to Tweets table

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -139,13 +139,13 @@ user from liking the same tweet twice.
 
 ## Indexes
 
-| Table    | Index / Key             | Use Case                                     |
-|:---------|:------------------------|:---------------------------------------------|
-| `users`  | `UNIQUE(email)`         | Fast user lookup during login.               |
-| `tweets` | `IDX(created_at DESC)`  | Chronological Feed generation.               |
-| `tweets` | `IDX(user_id)`          | Fetching all tweets by a specific user.      |
-| `likes`  | `PK(tweet_id, user_id)` | Checking whether a user liked a tweet.       |
-| `likes`  | `IDX(user_id)`          | Fetching a list of tweets liked by the user. |
+| Table    | Index / Key                            | Use Case                                     |
+|:---------|:---------------------------------------|:---------------------------------------------|
+| `users`  | `UNIQUE(email)`                        | Fast user lookup during login.               |
+| `tweets` | `IDX(created_at DESC,id DESC)`         | Chronological Feed generation.               |
+| `tweets` | `IDX(user_id,created_at DESC,id DESC)` | Fetching all tweets by a specific user.      |
+| `likes`  | `PK(tweet_id, user_id)`                | Checking whether a user liked a tweet.       |
+| `likes`  | `IDX(user_id)`                         | Fetching a list of tweets liked by the user. |
 
 ## Normalization
 

--- a/src/Tweet/Infrastructure/Persistence/Doctrine/Mapping/Tweet.Model.Tweet.orm.xml
+++ b/src/Tweet/Infrastructure/Persistence/Doctrine/Mapping/Tweet.Model.Tweet.orm.xml
@@ -7,6 +7,11 @@
     <entity name="Twitter\Tweet\Domain\Tweet\Model\Tweet"
             table="tweets">
 
+        <indexes>
+            <index name="idx_tweets_created_id" columns="created_at,id"/>
+            <index name="idx_tweets_user_created_id" columns="user_id,created_at,id"/>
+        </indexes>
+
         <id name="id" column="id" type="uuid">
             <generator strategy="NONE"/>
         </id>

--- a/src/Tweet/Infrastructure/Persistence/MySQL/Migration/Version20260408150600.php
+++ b/src/Tweet/Infrastructure/Persistence/MySQL/Migration/Version20260408150600.php
@@ -33,6 +33,12 @@ final class Version20260408150600 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->addSql('DROP TABLE tweets');
+        $this->addSql(
+            <<<SQL
+            ALTER TABLE tweets
+            DROP INDEX idx_tweets_created_id,
+            DROP INDEX idx_tweets_user_created_id;
+            SQL
+        );
     }
 }

--- a/src/Tweet/Infrastructure/Persistence/MySQL/Migration/Version20260408150600.php
+++ b/src/Tweet/Infrastructure/Persistence/MySQL/Migration/Version20260408150600.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twitter\Tweet\Infrastructure\Persistence\MySQL\Migration;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260408150600 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add tweets table indexes';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(
+            <<<SQL
+            ALTER TABLE tweets
+            ADD INDEX idx_tweets_created_id (created_at DESC, id DESC);
+            SQL
+        );
+
+        $this->addSql(
+            <<<SQL
+            ALTER TABLE tweets
+            ADD INDEX idx_tweets_user_created_id (user_id, created_at DESC, id DESC);
+            SQL
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE tweets');
+    }
+}


### PR DESCRIPTION
Adds 2 indexes to improve SQL performance on big datasets 1+ M

Drop query execution time for Main Feed and Profile Feeds from 1-2s to less than 50-150 ms under load

<img width="1006" height="1077" alt="Screenshot 2026-04-07 182452" src="https://github.com/user-attachments/assets/4cdbd3b5-ad06-4eec-b703-73776038242f" />
<img width="960" height="978" alt="Screenshot 2026-04-07 182429" src="https://github.com/user-attachments/assets/b82a1f61-a3e7-4ccf-ba0b-91a04291d455" />
<img width="1028" height="1085" alt="Screenshot 2026-04-07 182405" src="https://github.com/user-attachments/assets/fb9811c5-974a-4a1b-9b6c-27d93d976148" />
